### PR TITLE
Improve multichart responsiveness and add UI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ Thumbs.db
 *.gdoc
 *.gsheet
 *.tmp
-~$*
+~$*\nnode_modules/
+package-lock.json

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const html = fs.readFileSync('tools/asset/multichart.html', 'utf8');
+
+// Test 1: responsive grid class
+assert(html.includes('md:grid-cols-3'), 'Responsive grid class missing');
+
+// Test 2: y-axis tick callback formatting
+assert(html.includes('maximumFractionDigits: 2'), 'Tick format limit missing');
+assert(html.includes("'$' + fmt") && html.includes("fmt + '%'"), 'Tick format unit missing');
+
+// Test 3: arrow icons in summary table
+assert(html.includes('▲') && html.includes('▼'), 'Arrow icons missing');
+
+console.log('All tests passed!');

--- a/tools/asset/multichart.html
+++ b/tools/asset/multichart.html
@@ -284,13 +284,15 @@ async function fetchPriceDataAlpha(symbol) {
         if (!canvasRef.current) { setMessage('차트 캔버스 로드 실패.'); setIsLoading(false); return; }
 
         const dataMap = {};
-        const errs = [];
         for (const t of tickers) {
-          try { dataMap[t] = await fetchPriceData(t); } catch (e) { errs.push(`- ${t}: ${e.message}`); }
+          try {
+            dataMap[t] = await fetchPriceData(t);
+          } catch (e) {
+            showToast(`${t}: ${e.message}`, 'warn');
+          }
         }
-        if (errs.length) setMessage(errs.join('\n'));
-        const okTickers = tickers.filter(t => dataMap[t] && dataMap[t].length);
-        if (!okTickers.length) { setIsLoading(false); return; }
+        const okTickers = tickers.filter(t => Array.isArray(dataMap[t]) && dataMap[t].length);
+        if (!okTickers.length) { setMessage('데이터를 가져오지 못했습니다.'); setIsLoading(false); return; }
 
         const allDates = [...new Set(Object.values(dataMap).flat().map(p => p.date))].filter(d => d >= startDate && d <= endDate).sort();
         const datasets = [], summary = [];
@@ -300,13 +302,14 @@ async function fetchPriceDataAlpha(symbol) {
           const periodData = full.filter(d => d.date >= startDate && d.date <= endDate);
           if (!periodData.length) return;
           const color = getColor(i);
-          const prices = periodData.map(d => d.price);
+          const prices = periodData.map(d => d.price).filter(v => !isNaN(v));
           const first = prices[0], last = prices[prices.length - 1];
           let dataArr = allDates.map(d => {
             const p = periodData.find(x => x.date === d);
-            return p ? p.price : null;
+            const val = p ? p.price : null;
+            return (val == null || isNaN(val)) ? null : val;
           });
-          if (chartMode === 'normalized') dataArr = dataArr.map(v => v !== null ? (v / first - 1) * 100 : null);
+          if (chartMode === 'normalized') dataArr = dataArr.map(v => (v == null || isNaN(v)) ? null : (v / first - 1) * 100);
           else if (chartMode === 'benchmark') {
             const bench = dataMap[options.benchmarkTicker].filter(d => d.date >= startDate && d.date <= endDate);
             if (bench.length) {
@@ -314,7 +317,8 @@ async function fetchPriceDataAlpha(symbol) {
               dataArr = allDates.map(d => {
                 const pT = periodData.find(x => x.date === d);
                 const pB = bench.find(x => x.date === d);
-                return pT && pB ? ((pT.price / first) / (pB.price / bFirst) - 1) * 100 : null;
+                const val = pT && pB ? ((pT.price / first) / (pB.price / bFirst) - 1) * 100 : null;
+                return (val == null || isNaN(val)) ? null : val;
               });
             }
           }
@@ -322,15 +326,30 @@ async function fetchPriceDataAlpha(symbol) {
           if (chartMode === 'price' && options.showMA50) {
             const sma = calculateSMA(full, 50);
             const map = new Map(sma.map(p => [p.date, p.price]));
-            datasets.push({ label: `${t} 50SMA`, data: allDates.map(d => map.get(d) ?? null), borderColor: color, borderWidth: 1, borderDash: [5, 5], pointRadius: 0 });
+            datasets.push({ label: `${t} 50SMA`, data: allDates.map(d => {
+              const v = map.get(d);
+              return (v == null || isNaN(v)) ? null : v;
+            }), borderColor: color, borderWidth: 1, borderDash: [5, 5], pointRadius: 0 });
           }
-          summary.push({ sym: t, perf: (((last / first) - 1) * 100).toFixed(2), mdd: calculateMDD(prices).toFixed(2), volatility: calculateVolatility(prices).toFixed(2), color });
+          const perf = ((last / first) - 1) * 100;
+          const mdd = calculateMDD(prices);
+          const vol = calculateVolatility(prices);
+          summary.push({
+            sym: t,
+            perf: isNaN(perf) ? null : perf.toFixed(2),
+            mdd: isNaN(mdd) ? null : mdd.toFixed(2),
+            volatility: isNaN(vol) ? null : vol.toFixed(2),
+            color
+          });
         });
 
         setSummaryTable(summary.sort((a, b) => b.perf - a.perf));
         const diff = (new Date(endDate) - new Date(startDate)) / 86400000;
         const unit = diff <= 90 ? 'week' : diff <= 730 ? 'month' : diff <= 1825 ? 'quarter' : 'year';
-        const yCb = chartMode === 'price' ? v => '$' + v.toLocaleString() : v => v.toLocaleString() + '%';
+        const yCb = v => {
+          const fmt = v.toLocaleString(undefined, { maximumFractionDigits: 2 });
+          return chartMode === 'price' ? '$' + fmt : fmt + '%';
+        };
 
         chartRef.current = new Chart(canvasRef.current, {
           type: 'line',
@@ -348,16 +367,17 @@ async function fetchPriceDataAlpha(symbol) {
       useEffect(() => () => { if (chartRef.current) chartRef.current.destroy(); }, []);
 
       return (
-        <div className="p-4 sm:p-6 max-w-screen-xl mx-auto flex flex-col min-h-screen">
+        <div className="px-4 sm:px-6 md:px-8 py-4 md:py-6 max-w-screen-xl mx-auto flex flex-col min-h-screen">
           <main className="flex-grow">
             <h1 className="text-3xl font-bold mb-4 text-gray-800"><i className="fas fa-chart-line text-blue-600 mr-3"></i>100x&nbsp;Multichart&nbsp;Pro</h1>
             <ControlPanel {...{ rows, setRows, period, setPeriod, startDate, setStartDate, endDate, setEndDate, chartMode, setChartMode, options, setOptions, onUpdate: drawChart, isLoading }} />
             {message && <div className="mb-4 p-3 bg-yellow-100 text-yellow-800 border border-yellow-200 text-sm rounded-md whitespace-pre-wrap">{message}</div>}
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              <div className="lg:col-span-2 bg-white p-4 rounded-lg shadow-md">
-                <div className="relative h-[450px]"><canvas ref={canvasRef}></canvas></div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
+              <div className="md:col-span-2 bg-white p-4 sm:p-5 md:p-6 rounded-lg shadow-md">
+                <div className="relative h-[300px] sm:h-[450px]"><canvas ref={canvasRef}></canvas></div>
+                <div id="insights-panel" className="mt-4 p-3 text-center bg-gray-50 rounded-md text-sm text-gray-500">Insights coming soon...</div>
               </div>
-              <div className="lg:col-span-1 bg-white p-4 rounded-lg shadow-md">
+              <div className="md:col-span-1 bg-white p-4 sm:p-5 md:p-6 rounded-lg shadow-md">
                 <h3 className="font-semibold mb-3">성과 요약</h3>
                 <div className="overflow-y-auto max-h-[450px] custom-scrollbar">
                   <table className="w-full text-sm">
@@ -371,9 +391,16 @@ async function fetchPriceDataAlpha(symbol) {
                       {summaryTable.length ? summaryTable.map(r => (
                         <tr key={r.sym} className="border-b last:border-b-0">
                           <td className="px-2 py-2 font-medium flex items-center"><span className="inline-block w-2.5 h-2.5 mr-2 rounded-full" style={{ background: r.color }}></span>{r.sym}</td>
-                          <td className={`px-2 py-2 text-right font-semibold ${parseFloat(r.perf) >= 0 ? 'text-green-600' : 'text-red-500'}`}>{r.perf}%</td>
-                          <td className="px-2 py-2 text-right text-red-500">{r.mdd}%</td>
-                          <td className="px-2 py-2 text-right text-gray-600">{r.volatility}%</td>
+                          <td className="px-2 py-2 text-right font-semibold">
+                            {r.perf != null ? (
+                              <span className="flex items-center justify-end">
+                                {parseFloat(r.perf) >= 0 ? <span className="text-green-600">▲</span> : <span className="text-red-500">▼</span>}
+                                <span className={`ml-1 ${parseFloat(r.perf) >= 0 ? 'text-green-600' : 'text-red-500'}`}>{Math.abs(parseFloat(r.perf)).toFixed(2)}%</span>
+                              </span>
+                            ) : '-'}
+                          </td>
+                          <td className="px-2 py-2 text-right text-red-500">{r.mdd != null ? r.mdd + '%' : '-'}</td>
+                          <td className="px-2 py-2 text-right text-gray-600">{r.volatility != null ? r.volatility + '%' : '-'}</td>
                         </tr>
                       )) : <tr><td colSpan="4" className="text-center py-10 text-gray-500">분석을 실행해주세요.</td></tr>}
                     </tbody>


### PR DESCRIPTION
## Summary
- ignore node tooling files in `.gitignore`
- polish chart layout for mobile and add placeholder insights panel
- limit Y axis tick decimals and show `$` or `%`
- use ▲/▼ icons in performance table with color-coded numbers
- add simple Node tests verifying new UI features

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_68601f8dbd40832983885f08aa378944