### PR TITLE
Introduce central site version module

### DIFF
--- a/100x/daily-wrap/2025-06-21_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-21_100x-daily-wrap.html
@@ -455,11 +455,12 @@ false} } }
             }
         });
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../../version.js';
+        fetch(`../../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../../version.js"></script>
 </body>
 </html>

--- a/100x/daily-wrap/2025-06-24_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-24_100x-daily-wrap.html
@@ -913,11 +913,12 @@
             }
         });
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../../version.js';
+        fetch(`../../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../../version.js"></script>
 </body>
 </html>

--- a/100x/daily-wrap/2025-06-25_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-25_100x-daily-wrap.html
@@ -532,11 +532,12 @@
             }
         });
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../../version.js';
+        fetch(`../../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../../version.js"></script>
 </body>
 </html>

--- a/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
@@ -492,11 +492,12 @@
             }
         });
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../../version.js';
+        fetch(`../../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../../version.js"></script>
 </body>
 </html>

--- a/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
@@ -597,11 +597,12 @@
             }
         });
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../../version.js';
+        fetch(`../../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../../version.js"></script>
 </body>
 </html>

--- a/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
@@ -579,11 +579,12 @@
             }
         });
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../../version.js';
+        fetch(`../../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../../version.js"></script>
 </body>
 </html>

--- a/100x/index.html
+++ b/100x/index.html
@@ -211,11 +211,12 @@
             });
         });
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../version.js';
+        fetch(`../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../version.js"></script>
 </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -22,5 +22,6 @@
     <p class="mb-6 text-lg">죄송합니다. 요청하신 페이지를 찾을 수 없습니다.</p>
     <a href="./index.html" class="text-blue-600 hover:underline">메인 페이지로 돌아가기</a>
   </div>
+  <script type="module" src="./version.js"></script>
 </body>
 </html>

--- a/ib/ib-total-guide-calculator.html
+++ b/ib/ib-total-guide-calculator.html
@@ -520,11 +520,12 @@
             });
         });
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../version.js';
+        fetch(`../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../version.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -92,10 +92,10 @@ LLM_GUIDE_END -->
         <iframe id="content-frame" name="content-display-area" loading="lazy"></iframe>
     </div>
 
-    <script defer>
+    <script type="module">
         /* ──────────────── 설정 상수 ──────────────── */
         const ROOT        = '.';            // 사이트 루트 한곳에서 관리
-        const siteVersion = '20250628T1121';         // 수정 시 ↑ 숫자·시간만 갱신
+        import { siteVersion } from './version.js';
 
         const navFrame     = document.getElementById('nav-frame');
         const contentFrame = document.getElementById('content-frame');
@@ -129,5 +129,6 @@ LLM_GUIDE_END -->
             }, 150); // nav iframe 로드 대기
         }
     </script>
+  <script type="module" src="./version.js"></script>
 </body>
 </html>

--- a/main.html
+++ b/main.html
@@ -130,11 +130,12 @@
                 <p class="text-xs text-slate-400">© 2025 FenoK. 모든 정보는 투자 참고용이지만, 손실 나면 니 탓, 수익 나면 내 탓.<br>100x • QUANTUM POWERED</p>
         </div>
   </footer>
-  <script defer>
-    const siteVersion = '20250628T1121';
-    fetch('./nav.html?v=' + siteVersion)
+  <script type="module">
+        import { siteVersion } from './version.js';
+        fetch(`./nav.html?v=${siteVersion}`)
       .then(r => r.text())
       .then(html => { document.getElementById('nav').innerHTML = html; });
   </script>
+  <script type="module" src="./version.js"></script>
 </body>
 </html>

--- a/mona/hr.html
+++ b/mona/hr.html
@@ -294,5 +294,6 @@
             { label: '기술연구소', data: [3.2, 3.1, 3.4], backgroundColor: PALETTE.red }
         );
     </script>
+  <script type="module" src="../version.js"></script>
 </body>
 </html>

--- a/mona/hr2.html
+++ b/mona/hr2.html
@@ -396,5 +396,6 @@
             }
         });
     </script>
+  <script type="module" src="../version.js"></script>
 </body>
 </html>

--- a/nav.html
+++ b/nav.html
@@ -57,5 +57,6 @@
     btn.onclick = () => menu.classList.toggle('hidden');
     menu.onclick = e => e.target.tagName==='A' && menu.classList.add('hidden');
   </script>
+  <script type="module" src="./version.js"></script>
 </body>
 </html>

--- a/posts/2025-06-22_playbook.html
+++ b/posts/2025-06-22_playbook.html
@@ -630,11 +630,12 @@
         });
 
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../version.js';
+        fetch(`../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../version.js"></script>
 </body>
 </html>

--- a/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
+++ b/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
@@ -730,12 +730,13 @@
             <p class="text-xs text-slate-400">© 2025 FenoK. 모든 정보는 투자 참고용이지만, 손실 나면 니 탓, 수익 나면 내 탓.<br>100x • QUANTUM POWERED</p>
         </div>
     </footer>
-    <script defer>
-        const siteVersion = '20250628T1121';
+    <script type="module">
+        import { siteVersion } from '../version.js';
         fetch(`../nav.html?v=${siteVersion}`)
             .then(res => res.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
 
+  <script type="module" src="../version.js"></script>
 </body>
 </html>

--- a/posts/index.html
+++ b/posts/index.html
@@ -226,12 +226,13 @@
             <p class="text-xs text-slate-400">© 2025 FenoK. 모든 정보는 투자 참고용이지만, 손실 나면 니 탓, 수익 나면 내 탓.<br>100x • QUANTUM POWERED</p>
         </div>
     </footer>
-    <script defer>
-        const siteVersion = '20250628T1121';
+    <script type="module">
+        import { siteVersion } from '../version.js';
         fetch(`../nav.html?v=${siteVersion}`)
             .then(res => res.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
 
+  <script type="module" src="../version.js"></script>
 </body>
 </html>

--- a/tools/asset/multichart.html
+++ b/tools/asset/multichart.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <script defer>
-    const siteVersion = '20250628T1121';
+  <script type="module">
+        import { siteVersion } from '../../version.js';
     const cfg = document.createElement('script');
     cfg.defer = true;
     cfg.type = 'module';
@@ -493,5 +493,6 @@ async function fetchPriceDataAlpha(symbol) {
 </script>
 <!-- === override end === -->
 
+  <script type="module" src="../../version.js"></script>
 </body>
 </html>

--- a/version.js
+++ b/version.js
@@ -1,0 +1,1 @@
+export const siteVersion = '20250628T1121';

--- a/vr/index.html
+++ b/vr/index.html
@@ -226,11 +226,12 @@
         </div>
 
     </div>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../version.js';
+        fetch(`../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../version.js"></script>
 </body>
 </html>

--- a/vr/vr-complete-system.html
+++ b/vr/vr-complete-system.html
@@ -547,11 +547,12 @@
         }
     });
 </script>
-<script defer>
-    const siteVersion = '20250628T1121';
-    fetch('../nav.html?v=' + siteVersion)
+<script type="module">
+        import { siteVersion } from '../version.js';
+        fetch(`../nav.html?v=${siteVersion}`)
         .then(r => r.text())
         .then(html => { document.getElementById('nav').innerHTML = html; });
 </script>
+  <script type="module" src="../version.js"></script>
 </body>
 </html>

--- a/vr/vr-total-guide-calculator.html
+++ b/vr/vr-total-guide-calculator.html
@@ -462,11 +462,12 @@
             updateFormulaUI();
         });
     </script>
-    <script defer>
-        const siteVersion = '20250628T1121';
-        fetch('../nav.html?v=' + siteVersion)
+    <script type="module">
+        import { siteVersion } from '../version.js';
+        fetch(`../nav.html?v=${siteVersion}`)
             .then(r => r.text())
             .then(html => { document.getElementById('nav').innerHTML = html; });
     </script>
+  <script type="module" src="../version.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `version.js` providing `siteVersion`
- load the module on every page
- import `siteVersion` where navigation or assets are fetched

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_686030ba315083298c27a09de216d2a4