### PR TITLE
Combine deep-dive content into unified Alpha Pick page

### DIFF
--- a/preview/posts/2025-06-23_Alpha_Pick_RMD/integrated_alpha_pick.html
+++ b/preview/posts/2025-06-23_Alpha_Pick_RMD/integrated_alpha_pick.html
@@ -1,0 +1,1289 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>기관급 투자 분석 플랫폼 | 4개 기업 종합 분석</title>
+    <meta name="description" content="전문 투자 분석가를 위한 기관급 투자 분석 플랫폼 - ResMed, Trimble, Abbott, Edwards 종합 분석">
+    
+    <!-- Chart.js -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="style.css">
+    <!-- Additional resources from deep-dive page -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700;900&family=Roboto:wght@400;700;900&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Noto Sans KR', sans-serif;
+            background-color: #0D1117;
+            color: #C9D1D9;
+        }
+        .font-roboto {
+            font-family: 'Roboto', sans-serif;
+        }
+        .glass-card {
+            background: rgba(22, 27, 34, 0.6);
+            backdrop-filter: blur(10px);
+            border: 1px solid rgba(48, 54, 61, 0.5);
+        }
+        .scroll-fade-in {
+            opacity: 0;
+            transform: translateY(20px);
+            transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+        }
+        .scroll-fade-in.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        #side-nav .nav-link {
+            transition: all 0.2s ease-in-out;
+            color: #8B949E;
+            border-left: 2px solid transparent;
+            padding: 0.5rem 1rem;
+            font-size: 0.875rem;
+        }
+        #side-nav .nav-link:hover {
+            color: #C9D1D9;
+            border-left-color: #30363D;
+        }
+        #side-nav .nav-link.active {
+            color: #58A6FF;
+            font-weight: 700;
+            border-left-color: #58A6FF;
+        }
+        .flip-card {
+            background-color: transparent;
+            perspective: 1000px;
+            cursor: pointer;
+        }
+        .flip-card-inner {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            transition: transform 0.8s;
+            transform-style: preserve-3d;
+        }
+        .flip-card:hover .flip-card-inner,
+        .flip-card.is-active .flip-card-inner {
+            transform: rotateY(180deg);
+        }
+        .flip-card-front, .flip-card-back {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            -webkit-backface-visibility: hidden;
+            backface-visibility: hidden;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+        }
+        .flip-card-front {
+            background-color: #161B22;
+            border: 1px solid #30363D;
+        }
+        .flip-card-back {
+            background-color: #010409;
+            border: 1px solid #58A6FF;
+            transform: rotateY(180deg);
+            color: #C9D1D9;
+        }
+        .chart-container {
+            position: relative;
+            width: 100%;
+            margin-left: auto;
+            margin-right: auto;
+            max-width: 800px;
+            height: 400px;
+        }
+        @media (max-width: 768px) {
+            .chart-container {
+                height: 350px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Top Navigation -->
+    <nav class="top-nav">
+        <div class="nav-left">
+            <div class="logo">
+                <i class="fas fa-chart-line"></i>
+                <span>투자분석플랫폼</span>
+            </div>
+            <div class="nav-tabs">
+                <button class="nav-tab active" data-tab="dashboard">대시보드</button>
+                <button class="nav-tab" data-tab="analysis">종합분석</button>
+                <button class="nav-tab" data-tab="financials">재무분석</button>
+                <button class="nav-tab" data-tab="risk">리스크평가</button>
+                <button class="nav-tab" data-tab="portfolio">포트폴리오</button>
+            </div>
+        </div>
+        <div class="nav-right">
+            <div class="market-status">
+                <span class="status-indicator live"></span>
+                <span>실시간 데이터</span>
+            </div>
+            <div class="last-updated">
+                마지막 업데이트: 2025-06-29 22:29
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <div class="main-content">
+        <!-- Executive Dashboard -->
+        <div class="tab-content active" id="dashboard">
+            <div class="dashboard-grid">
+                <!-- Market Overview -->
+                <div class="panel market-overview">
+                    <div class="panel-header">
+                        <h3>시장 개요</h3>
+                        <div class="refresh-btn">
+                            <i class="fas fa-sync-alt"></i>
+                        </div>
+                    </div>
+                    <div class="panel-content">
+                        <div class="market-metrics">
+                            <div class="metric">
+                                <div class="metric-label">S&P 500 YTD</div>
+                                <div class="metric-value positive">+5.2%</div>
+                            </div>
+                            <div class="metric">
+                                <div class="metric-label">헬스케어 섹터</div>
+                                <div class="metric-value negative">-2.1%</div>
+                            </div>
+                            <div class="metric">
+                                <div class="metric-label">VIX</div>
+                                <div class="metric-value">16.8</div>
+                            </div>
+                            <div class="metric">
+                                <div class="metric-label">10Y 국채수익률</div>
+                                <div class="metric-value">4.25%</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Top Recommendation -->
+                <div class="panel top-recommendation">
+                    <div class="panel-header">
+                        <h3>최고 추천 종목</h3>
+                        <div class="confidence-badge">신뢰도 92%</div>
+                    </div>
+                    <div class="panel-content">
+                        <div class="recommendation-card">
+                            <div class="stock-info">
+                                <div class="ticker">RMD</div>
+                                <div class="company-name">ResMed Inc.</div>
+                                <div class="rating strong-buy">STRONG BUY</div>
+                            </div>
+                            <div class="target-return">
+                                <div class="return-value">+15%</div>
+                                <div class="return-label">목표 수익률 (6개월)</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Company Rankings -->
+                <div class="panel company-rankings">
+                    <div class="panel-header">
+                        <h3>종합 평가 순위</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="ranking-list">
+                            <div class="ranking-item">
+                                <div class="rank">1</div>
+                                <div class="company-info">
+                                    <span class="ticker">RMD</span>
+                                    <span class="name">ResMed</span>
+                                </div>
+                                <div class="score">89.5</div>
+                                <div class="recommendation strong-buy">STRONG BUY</div>
+                            </div>
+                            <div class="ranking-item">
+                                <div class="rank">2</div>
+                                <div class="company-info">
+                                    <span class="ticker">TRMB</span>
+                                    <span class="name">Trimble</span>
+                                </div>
+                                <div class="score">80.9</div>
+                                <div class="recommendation buy">BUY</div>
+                            </div>
+                            <div class="ranking-item">
+                                <div class="rank">3</div>
+                                <div class="company-info">
+                                    <span class="ticker">ABT</span>
+                                    <span class="name">Abbott</span>
+                                </div>
+                                <div class="score">79.4</div>
+                                <div class="recommendation hold">HOLD</div>
+                            </div>
+                            <div class="ranking-item">
+                                <div class="rank">4</div>
+                                <div class="company-info">
+                                    <span class="ticker">EW</span>
+                                    <span class="name">Edwards</span>
+                                </div>
+                                <div class="score">74.4</div>
+                                <div class="recommendation hold">HOLD</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Key Metrics Chart -->
+                <div class="panel chart-panel">
+                    <div class="panel-header">
+                        <h3>핵심 지표 비교</h3>
+                        <div class="chart-controls">
+                            <select id="metricSelector">
+                                <option value="scores">종합 점수</option>
+                                <option value="returns">예상 수익률</option>
+                                <option value="confidence">신뢰도</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="panel-content">
+                        <div class="chart-container">
+                            <canvas id="keyMetricsChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Risk-Return Scatter -->
+                <div class="panel chart-panel">
+                    <div class="panel-header">
+                        <h3>리스크-수익률 포지셔닝</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="chart-container">
+                            <canvas id="riskReturnChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Recent Activity -->
+                <div class="panel activity-panel">
+                    <div class="panel-header">
+                        <h3>최근 활동</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="activity-list">
+                            <div class="activity-item">
+                                <div class="activity-icon upgrade">
+                                    <i class="fas fa-arrow-up"></i>
+                                </div>
+                                <div class="activity-text">
+                                    <strong>RMD</strong> 목표가 상향 조정: $290 → $295
+                                </div>
+                                <div class="activity-time">2시간 전</div>
+                            </div>
+                            <div class="activity-item">
+                                <div class="activity-icon news">
+                                    <i class="fas fa-newspaper"></i>
+                                </div>
+                                <div class="activity-text">
+                                    <strong>TRMB</strong> Q4 실적 발표 예정
+                                </div>
+                                <div class="activity-time">5시간 전</div>
+                            </div>
+                            <div class="activity-item">
+                                <div class="activity-icon analysis">
+                                    <i class="fas fa-chart-bar"></i>
+                                </div>
+                                <div class="activity-text">
+                                    포트폴리오 가중치 업데이트 완료
+                                </div>
+                                <div class="activity-time">1일 전</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+        </div>
+    </div>
+
+            <header class="text-center mb-20">
+                <p class="font-roboto font-bold text-blue-400">100x FenoK Alpha Pick</p>
+                <h1 class="font-roboto text-5xl md:text-7xl font-black text-white tracking-tighter my-4">ResMed (RMD)</h1>
+                <p class="text-lg text-gray-400 max-w-3xl mx-auto">독점적 시장 지위, 시장이 오해한 GLP-1 촉매제, 그리고 탁월한 자본 효율성을 바탕으로 최고의 투자 기회로 부상한 이유를 심층 분석합니다.</p>
+            </header>
+
+            <section id="hero" class="mb-24 scroll-section">
+                <h2 class="text-3xl font-bold text-center text-white mb-4">왜 RMD인가?</h2>
+                <p class="text-center text-gray-400 mb-12 max-w-2xl mx-auto">ResMed의 투자 매력은 세 가지 강력하고 상호 보완적인 핵심 논리에 기반합니다. 각 요소는 단독으로도 강력하지만, 결합되었을 때 특별한 투자 기회를 창출합니다.</p>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                    <div class="glass-card rounded-xl p-6 text-center scroll-fade-in">
+                        <div class="text-4xl mb-4">🛡️</div>
+                        <h3 class="text-xl font-bold text-white mb-2">독점적 시장 지위</h3>
+                        <p class="text-gray-400 text-sm">경쟁사(Philips)의 대규모 리콜 사태로 인해 형성된 독과점적 위치는 강력한 가격 결정력과 안정적인 마진 확보를 가능하게 하는 깊은 해자를 구축했습니다.</p>
+                    </div>
+                    <div class="glass-card rounded-xl p-6 text-center scroll-fade-in" style="transition-delay: 150ms;">
+                        <div class="text-4xl mb-4">🚀</div>
+                        <h3 class="text-xl font-bold text-white mb-2">잘못 인식된 기회 (GLP-1)</h3>
+                        <p class="text-gray-400 text-sm">시장은 비만 치료제를 위협으로 오해했지만, 실제로는 새로운 환자군을 수면 무호흡증 시장으로 유입시켜 성장을 가속화하는 강력한 순풍으로 작용하고 있습니다.</p>
+                    </div>
+                    <div class="glass-card rounded-xl p-6 text-center scroll-fade-in" style="transition-delay: 300ms;">
+                        <div class="text-4xl mb-4">📈</div>
+                        <h3 class="text-xl font-bold text-white mb-2">탁월한 자본 효율성</h3>
+                        <p class="text-gray-400 text-sm">업계 최고 수준의 투하자본수익률(ROIC)과 잉여현금흐름(FCF) 전환율은 경영진의 뛰어난 자본 배분 능력을 증명하며, 지속 가능한 주주 가치 창출을 보장합니다.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section id="comparison" class="mb-24 scroll-section">
+                <h2 class="text-3xl font-bold text-center text-white mb-4">종합 비교 분석</h2>
+                <p class="text-center text-gray-400 mb-12 max-w-2xl mx-auto">4개 후보 기업을 정량적으로 평가한 결과, ResMed는 모든 면에서 가장 높은 점수를 획득하며 명확한 선두주자임을 입증했습니다.</p>
+
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-12">
+                    <div class="glass-card rounded-xl p-6 scroll-fade-in">
+                        <h3 class="text-xl font-bold text-white mb-2">최종 가중점수 비교</h3>
+                        <p class="text-sm text-gray-400 mb-4">15개 핵심 역량에 대한 가중 평가 결과, RMD가 가장 높은 종합 점수로 1위를 차지했습니다.</p>
+                        <div class="chart-container h-80">
+                            <canvas id="weightedScoreChart"></canvas>
+                        </div>
+                    </div>
+                    <div class="glass-card rounded-xl p-6 scroll-fade-in">
+                        <h3 class="text-xl font-bold text-white mb-2">핵심 역량비교 (레이더 차트)</h3>
+                        <p class="text-sm text-gray-400 mb-4">기업별 강점과 약점을 한눈에 비교할 수 있습니다. RMD는 대부분의 영역에서 균형 잡힌 우위를 보여줍니다.</p>
+                        <div class="chart-container h-80">
+                            <canvas id="competencyRadarChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section id="scenario" class="mb-24 scroll-section">
+                <h2 class="text-3xl font-bold text-center text-white mb-4">시나리오 분석: 기대 수익률</h2>
+                <p class="text-center text-gray-400 mb-12 max-w-2xl mx-auto">강세/기본/약세 시나리오별 목표 수익률을 S&P 500 예상 수익률과 비교하여 RMD의 매력적인 위험-보상 프로필을 확인합니다.</p>
+                <div class="glass-card rounded-xl p-6 scroll-fade-in">
+                    <h3 class="text-xl font-bold text-white mb-2">시나리오별 기대 수익률 범위</h3>
+                    <p class="text-sm text-gray-400 mb-4">RMD는 약세 시나리오에서도 자본 손실 위험이 없는 반면, 강세 시나리오에서는 높은 상승 잠재력을 보여줍니다.</p>
+                    <div class="chart-container h-96">
+                        <canvas id="scenarioChartDeepDive"></canvas>
+                    </div>
+                </div>
+            </section>
+
+            <section id="deep-dive" class="mb-24 scroll-section">
+                <h2 class="text-3xl font-bold text-center text-white mb-4">심층분석</h2>
+                <p class="text-center text-gray-400 mb-12 max-w-2xl mx-auto">각 기업의 투자 유형과 핵심 분석 내용을 살펴봅니다. 카드에 마우스를 올리거나 클릭하여 상세 정보를 확인하세요.</p>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-12">
+                    <div class="flip-card h-56 scroll-fade-in">
+                        <div class="flip-card-inner">
+                            <div class="flip-card-front"><h3 class="text-2xl font-bold text-white">ResMed (RMD)</h3><p class="text-blue-400">방어적 성장 리더</p></div>
+                            <div class="flip-card-back"><h4 class="font-bold mb-2">최종 추천 (Top Pick)</h4><p class="text-xs text-center">견고한 해자와 뛰어난 자본 효율성, 예상치 못한 성장 촉매제를 보유한 가장 균형 잡힌 투자처.</p></div>
+                        </div>
+                    </div>
+                    <div class="flip-card h-56 scroll-fade-in" style="transition-delay: 100ms;">
+                        <div class="flip-card-inner">
+                            <div class="flip-card-front"><h3 class="text-2xl font-bold text-white">Trimble (TRMB)</h3><p class="text-blue-400">경기 순응적 혁신가</p></div>
+                            <div class="flip-card-back"><h4 class="font-bold mb-2">2순위 (Runner-up)</h4><p class="text-xs text-center">건설 및 인프라 시장의 구조적 성장에 베팅하는 매력적인 선택지이나, 경기 변동에 대한 민감도가 존재.</p></div>
+                        </div>
+                    </div>
+                    <div class="flip-card h-56 scroll-fade-in" style="transition-delay: 200ms;">
+                        <div class="flip-card-inner">
+                            <div class="flip-card-front"><h3 class="text-2xl font-bold text-white">Abbott (ABT)</h3><p class="text-blue-400">포트폴리오 앵커</p></div>
+                            <div class="flip-card-back"><h4 class="font-bold mb-2">안정적 선택지</h4><p class="text-xs text-center">다각화된 사업부와 안정적인 배당을 제공하는 훌륭한 핵심 보유 자산. 폭발적인 알파 기대는 제한적.</p></div>
+                        </div>
+                    </div>
+                    <div class="flip-card h-56 scroll-fade-in" style="transition-delay: 300ms;">
+                        <div class="flip-card-inner">
+                            <div class="flip-card-front"><h3 class="text-2xl font-bold text-white">Edwards (EW)</h3><p class="text-blue-400">고위험/고수익</p></div>
+                            <div class="flip-card-back"><h4 class="font-bold mb-2">잠재적 다크호스</h4><p class="text-xs text-center">TAVR 시장의 혁신을 주도하지만, 높은 밸류에이션과 경쟁 심화 리스크가 상존하여 변동성이 큼.</p></div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="prose prose-invert max-w-none prose-h3:text-blue-400 prose-h3:font-bold prose-h4:text-gray-300 prose-a:text-blue-400 hover:prose-a:text-blue-300">
+                    <p>아래는 "4기업 투자 판단 보고서"의 핵심 내용을 요약, 발췌한 것입니다. 각 기업의 성장 동력, 경쟁 환경, 경영 성과, 그리고 밸류에이션에 대한 상세한 분석을 제공합니다.</p>
+
+                    <h3>ResMed (RMD) 심층 분석</h3>
+                    <h4>성장성 및 혁신 파이프라인</h4>
+                    <p>RMD의 성장은 비재량적 수요에 기반한 '방어적' 측면과 디지털 헬스케어 생태계 확장을 통한 '공격적' 측면을 모두 갖추고 있습니다. 특히, 시장이 위협으로 간주했던 GLP-1 비만 치료제는 체중 감량 후에도 잔존하는 수면 무호흡증 환자를 치료 시장으로 유입시키는 역할을 하며, 오히려 새로운 성장 동력으로 작용할 가능성이 높습니다. 이는 시장의 오해에서 비롯된 기회입니다.</p>
+
+                    <h4>전략적 해자 및 경쟁 환경</h4>
+                    <p>주요 경쟁사인 필립스의 대규모 리콜 사태는 RMD에게 예상치 못한 반사이익을 안겨주었습니다. 이는 단순한 일회성 점유율 상승을 넘어, 의사와 환자들의 신뢰를 바탕으로 한 장기적인 '록인(Lock-in) 효과'로 이어지고 있습니다. 이로 인해 RMD는 강력한 가격 결정력을 확보했으며, 이는 높은 마진으로 증명됩니다.</p>
+
+                    <h3>Trimble (TRMB) 심층 분석</h3>
+                    <h4>성장성 및 혁신 파이프라인</h4>
+                    <p>Trimble은 건설, 농업 등 인프라 산업의 디지털 전환을 선도하는 기업입니다. 자율주행 건설 장비, 정밀 농업 솔루션 등은 생산성 향상이라는 명확한 가치를 제공하며 구조적 성장을 이끌고 있습니다. 인플레이션 감축법(IRA)과 같은 정부 주도 인프라 투자는 TRMB에게 강력한 순풍이 될 것입니다.</p>
+
+                    <h3>Abbott (ABT) 심층 분석</h3>
+                    <h4>전략적 해자 및 경쟁 환경</h4>
+                    <p>Abbott의 가장 큰 강점은 의료기기, 진단, 영양, 제약 등 다각화된 사업 포트폴리오입니다. 이는 특정 사업부의 부진을 다른 사업부가 상쇄해주는 안정성을 제공합니다. 특히 연속 혈당 측정기 '프리스타일 리브레'는 당뇨병 관리 시장의 게임 체인저로, 강력한 성장 동력입니다.</p>
+
+                    <h3>Edwards (EW) 심층 분석</h3>
+                    <h4>밸류에이션 및 시장 심리</h4>
+                    <p>Edwards는 경피적 대동맥판막 치환술(TAVR) 시장의 선구자이자 지배자입니다. 혁신적인 기술력은 높은 평가를 받지만, 이는 밸류에이션에도 반영되어 있습니다. 시장은 지속적인 고성장을 기대하고 있으며, 만약 경쟁 심화나 신제품 출시 지연 등의 이슈가 발생할 경우 주가 변동성이 커질 수 있는 리스크가 있습니다.</p>
+                </div>
+            </section>
+
+            <section id="conclusion" class="scroll-section">
+                <h2 class="text-3xl font-bold text-center text-white mb-4">결론 및 리스크 요인</h2>
+                <p class="text-center text-gray-400 mb-12 max-w-2xl mx-auto">최종 투자 추천을 다시 한번 강조하며, 성공적인 투자를 위해 반드시 고려해야 할 잠재적 리스크 요인을 제시합니다.</p>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                    <div class="glass-card rounded-xl p-6 border-l-4 border-green-400 scroll-fade-in">
+                        <h3 class="font-bold text-xl text-white mb-3">최종 투자 추천: ResMed (RMD)</h3>
+                        <p class="text-gray-400">분석 결과, RMD는 가장 매력적인 위험 조정 수익률을 제공합니다. 견고한 방어적 성장성, 시장이 오해하는 새로운 성장 동력, 그리고 경영진의 검증된 자본 배분 능력을 고려할 때, RMD는 향후 6개월간 5%비중의 '인사이트' 포트폴리오 편입 종목으로 가장 적합합니다.</p>
+                        <ul class="text-sm text-gray-400 mt-4 space-y-1">
+                            <li><strong class="text-white">1순위 (Top Pick):</strong> ResMed (RMD)</li>
+                            <li><strong class="text-white">2순위 (Runner-up):</strong> Trimble (TRMB)</li>
+                            <li><strong class="text-white">포트폴리오 앵커:</strong> Abbott (ABT)</li>
+                            <li><strong class="text-white">고위험/고수익:</strong> Edwards (EW)</li>
+                        </ul>
+                    </div>
+                    <div class="glass-card rounded-xl p-6 border-l-4 border-red-500 scroll-fade-in">
+                        <h3 class="font-bold text-xl text-white mb-3">주요 리스크 요인</h3>
+                        <p class="text-gray-400">모든 투자에는 리스크가 따릅니다. RMD 투자 시 다음 사항들을 주의 깊게 모니터링해야 합니다.</p>
+                        <ul class="text-sm list-disc list-inside text-gray-400 mt-4 space-y-1">
+                            <li><strong class="text-white">GLP-1 영향 재평가:</strong> 시장이 GLP-1의 영향을 긍정적으로 재해석했지만, 예상보다 체중 감량 효과가 더 크게 나타나거나 사용이 광범위해질 경우, 환자 수 증가폭이 기대에 미치지 못할수 있습니다.</li>
+                            <li><strong class="text-white">경쟁사 회복:</strong> 필립스가 리콜 문제를 해결하고 시장에 성공적으로 복귀할 경우, RMD의 독점적 지위가 약화되고 가격 경쟁이 심화될 수 있습니다.</li>
+                            <li><strong class="text-white">공급망 및 규제 리스크:</strong> 모든 의료기기 업체와 마찬가지로, 예기치 못한 공급망 문제나 각국의 의료 규제 변경은 실적에 영향을 줄 수 있습니다.</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <footer class="text-center mt-24 pt-12 border-t border-gray-800">
+                <p class="font-roboto font-black text-2xl text-white">100x • QUANTUM POWERED</p>
+                <p class="text-sm text-gray-500 mt-2">Analyzed by El Fenomeno Kim</p>
+                <p class="text-xs text-gray-600 mt-1">Published on 2025-07-02</p>
+            </footer>
+
+        <!-- Comprehensive Analysis Tab -->
+        <div class="tab-content" id="analysis">
+            <div class="analysis-grid">
+                <!-- Scoring Framework -->
+                <div class="panel scoring-framework">
+                    <div class="panel-header">
+                        <h3>15-기준 평가 프레임워크</h3>
+                        <div class="methodology-btn">
+                            <i class="fas fa-info-circle"></i>
+                            <span>방법론</span>
+                        </div>
+                    </div>
+                    <div class="panel-content">
+                        <div class="chart-container large">
+                            <canvas id="radarChart"></canvas>
+                        </div>
+                        <div class="criteria-weights">
+                            <h4>가중치 체계</h4>
+                            <div class="weight-list">
+                                <div class="weight-item">
+                                    <span class="weight-label">성장성</span>
+                                    <span class="weight-bar">
+                                        <span class="weight-fill" style="width: 30%"></span>
+                                    </span>
+                                    <span class="weight-value">30%</span>
+                                </div>
+                                <div class="weight-item">
+                                    <span class="weight-label">경쟁우위</span>
+                                    <span class="weight-bar">
+                                        <span class="weight-fill" style="width: 30%"></span>
+                                    </span>
+                                    <span class="weight-value">30%</span>
+                                </div>
+                                <div class="weight-item">
+                                    <span class="weight-label">밸류에이션</span>
+                                    <span class="weight-bar">
+                                        <span class="weight-fill" style="width: 25%"></span>
+                                    </span>
+                                    <span class="weight-value">25%</span>
+                                </div>
+                                <div class="weight-item">
+                                    <span class="weight-label">경영진</span>
+                                    <span class="weight-bar">
+                                        <span class="weight-fill" style="width: 15%"></span>
+                                    </span>
+                                    <span class="weight-value">15%</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Scenario Analysis -->
+                <div class="panel scenario-analysis">
+                    <div class="panel-header">
+                        <h3>시나리오 분석 & 확률 분포</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="chart-container">
+                            <canvas id="scenarioChart"></canvas>
+                        </div>
+                        <div class="scenario-probabilities">
+                            <div class="prob-item rmd">
+                                <div class="company-header">
+                                    <span class="ticker">RMD</span>
+                                    <span class="company">ResMed</span>
+                                </div>
+                                <div class="prob-bars">
+                                    <div class="prob-bar bull" style="width: 35%">
+                                        <span>Bull 35%</span>
+                                    </div>
+                                    <div class="prob-bar base" style="width: 45%">
+                                        <span>Base 45%</span>
+                                    </div>
+                                    <div class="prob-bar bear" style="width: 20%">
+                                        <span>Bear 20%</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Financial Analysis Tab -->
+        <div class="tab-content" id="financials">
+            <div class="financials-grid">
+                <!-- Financial Ratios Table -->
+                <div class="panel financial-table">
+                    <div class="panel-header">
+                        <h3>핵심 재무 지표 비교</h3>
+                        <div class="export-btn">
+                            <i class="fas fa-download"></i>
+                            <span>내보내기</span>
+                        </div>
+                    </div>
+                    <div class="panel-content">
+                        <div class="table-container">
+                            <table class="financial-metrics-table">
+                                <thead>
+                                    <tr>
+                                        <th>지표</th>
+                                        <th>RMD</th>
+                                        <th>TRMB</th>
+                                        <th>ABT</th>
+                                        <th>EW</th>
+                                        <th>업계 평균</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>P/E 비율</td>
+                                        <td class="metric-value">28.5</td>
+                                        <td class="metric-value">23.0</td>
+                                        <td class="metric-value highlight-best">17.4</td>
+                                        <td class="metric-value">25.3</td>
+                                        <td class="metric-value">23.6</td>
+                                    </tr>
+                                    <tr>
+                                        <td>EV/EBITDA</td>
+                                        <td class="metric-value">17.0</td>
+                                        <td class="metric-value">17.0</td>
+                                        <td class="metric-value">18.5</td>
+                                        <td class="metric-value highlight-worst">23.0</td>
+                                        <td class="metric-value">18.9</td>
+                                    </tr>
+                                    <tr>
+                                        <td>FCF 수익률 (%)</td>
+                                        <td class="metric-value">3.9</td>
+                                        <td class="metric-value">2.9</td>
+                                        <td class="metric-value highlight-best">6.3</td>
+                                        <td class="metric-value">4.0</td>
+                                        <td class="metric-value">4.3</td>
+                                    </tr>
+                                    <tr>
+                                        <td>ROE (%)</td>
+                                        <td class="metric-value highlight-best">21.2</td>
+                                        <td class="metric-value">15.8</td>
+                                        <td class="metric-value">14.2</td>
+                                        <td class="metric-value">18.9</td>
+                                        <td class="metric-value">17.5</td>
+                                    </tr>
+                                    <tr>
+                                        <td>ROIC (%)</td>
+                                        <td class="metric-value highlight-best">23.6</td>
+                                        <td class="metric-value">18.2</td>
+                                        <td class="metric-value">11.9</td>
+                                        <td class="metric-value">20.1</td>
+                                        <td class="metric-value">18.5</td>
+                                    </tr>
+                                    <tr>
+                                        <td>부채비율</td>
+                                        <td class="metric-value highlight-best">0.12</td>
+                                        <td class="metric-value">0.35</td>
+                                        <td class="metric-value">0.42</td>
+                                        <td class="metric-value">0.28</td>
+                                        <td class="metric-value">0.29</td>
+                                    </tr>
+                                    <tr>
+                                        <td>총마진율 (%)</td>
+                                        <td class="metric-value">59.9</td>
+                                        <td class="metric-value">66.7</td>
+                                        <td class="metric-value">57.1</td>
+                                        <td class="metric-value highlight-best">78.7</td>
+                                        <td class="metric-value">65.6</td>
+                                    </tr>
+                                    <tr>
+                                        <td>영업마진율 (%)</td>
+                                        <td class="metric-value">24.8</td>
+                                        <td class="metric-value">19.4</td>
+                                        <td class="metric-value">21.0</td>
+                                        <td class="metric-value highlight-best">28.5</td>
+                                        <td class="metric-value">23.4</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Valuation Multiples -->
+                <div class="panel valuation-multiples">
+                    <div class="panel-header">
+                        <h3>밸류에이션 배수</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="chart-container">
+                            <canvas id="valuationChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Target Price Analysis -->
+                <div class="panel target-price">
+                    <div class="panel-header">
+                        <h3>목표가 분석</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="target-price-grid">
+                            <div class="price-card rmd">
+                                <div class="price-header">
+                                    <span class="ticker">RMD</span>
+                                    <span class="current-price">$255.16</span>
+                                </div>
+                                <div class="price-targets">
+                                    <div class="target-item">
+                                        <span class="firm">JP Morgan</span>
+                                        <span class="target">$290</span>
+                                        <span class="upside positive">+13.6%</span>
+                                    </div>
+                                    <div class="target-item">
+                                        <span class="firm">Goldman</span>
+                                        <span class="target">$275</span>
+                                        <span class="upside positive">+7.8%</span>
+                                    </div>
+                                    <div class="target-item">
+                                        <span class="firm">Morgan Stanley</span>
+                                        <span class="target">$265</span>
+                                        <span class="upside positive">+3.8%</span>
+                                    </div>
+                                    <div class="consensus">
+                                        <span class="label">컨센서스</span>
+                                        <span class="target">$277</span>
+                                        <span class="upside positive">+8.5%</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Risk Assessment Tab -->
+        <div class="tab-content" id="risk">
+            <div class="risk-grid">
+                <!-- Risk Matrix -->
+                <div class="panel risk-matrix">
+                    <div class="panel-header">
+                        <h3>리스크 매트릭스</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="risk-heatmap">
+                            <div class="risk-categories">
+                                <div class="risk-category">
+                                    <span class="category-label">거시경제</span>
+                                    <div class="risk-levels">
+                                        <div class="risk-level low">RMD</div>
+                                        <div class="risk-level high">TRMB</div>
+                                        <div class="risk-level low">ABT</div>
+                                        <div class="risk-level high">EW</div>
+                                    </div>
+                                </div>
+                                <div class="risk-category">
+                                    <span class="category-label">규제</span>
+                                    <div class="risk-levels">
+                                        <div class="risk-level medium">RMD</div>
+                                        <div class="risk-level low">TRMB</div>
+                                        <div class="risk-level medium">ABT</div>
+                                        <div class="risk-level high">EW</div>
+                                    </div>
+                                </div>
+                                <div class="risk-category">
+                                    <span class="category-label">경쟁</span>
+                                    <div class="risk-levels">
+                                        <div class="risk-level low">RMD</div>
+                                        <div class="risk-level medium">TRMB</div>
+                                        <div class="risk-level medium">ABT</div>
+                                        <div class="risk-level medium">EW</div>
+                                    </div>
+                                </div>
+                                <div class="risk-category">
+                                    <span class="category-label">기술</span>
+                                    <div class="risk-levels">
+                                        <div class="risk-level low">RMD</div>
+                                        <div class="risk-level medium">TRMB</div>
+                                        <div class="risk-level low">ABT</div>
+                                        <div class="risk-level high">EW</div>
+                                    </div>
+                                </div>
+                                <div class="risk-category">
+                                    <span class="category-label">환율</span>
+                                    <div class="risk-levels">
+                                        <div class="risk-level medium">RMD</div>
+                                        <div class="risk-level medium">TRMB</div>
+                                        <div class="risk-level medium">ABT</div>
+                                        <div class="risk-level low">EW</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ESG Scores -->
+                <div class="panel esg-analysis">
+                    <div class="panel-header">
+                        <h3>ESG 평가 & 지속가능성</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="esg-chart-container">
+                            <canvas id="esgChart"></canvas>
+                        </div>
+                        <div class="esg-details">
+                            <div class="esg-company rmd">
+                                <div class="company-name">ResMed (RMD)</div>
+                                <div class="esg-scores">
+                                    <div class="esg-score">
+                                        <span class="label">E</span>
+                                        <span class="value">75</span>
+                                    </div>
+                                    <div class="esg-score">
+                                        <span class="label">S</span>
+                                        <span class="value">82</span>
+                                    </div>
+                                    <div class="esg-score">
+                                        <span class="label">G</span>
+                                        <span class="value">88</span>
+                                    </div>
+                                    <div class="esg-total">
+                                        <span class="label">총점</span>
+                                        <span class="value">82</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Risk Metrics -->
+                <div class="panel risk-metrics">
+                    <div class="panel-header">
+                        <h3>리스크 지표</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="risk-metrics-grid">
+                            <div class="risk-metric">
+                                <div class="metric-label">포트폴리오 VaR (95%)</div>
+                                <div class="metric-value">18.0%</div>
+                                <div class="metric-trend">
+                                    <i class="fas fa-arrow-down"></i>
+                                    <span>-2.1%</span>
+                                </div>
+                            </div>
+                            <div class="risk-metric">
+                                <div class="metric-label">최대 손실폭</div>
+                                <div class="metric-value">12.0%</div>
+                                <div class="metric-trend">
+                                    <i class="fas fa-arrow-up"></i>
+                                    <span>+1.3%</span>
+                                </div>
+                            </div>
+                            <div class="risk-metric">
+                                <div class="metric-label">샤프 비율</div>
+                                <div class="metric-value">1.42</div>
+                                <div class="metric-trend">
+                                    <i class="fas fa-arrow-up"></i>
+                                    <span>+0.15</span>
+                                </div>
+                            </div>
+                            <div class="risk-metric">
+                                <div class="metric-label">소르티노 비율</div>
+                                <div class="metric-value">1.89</div>
+                                <div class="metric-trend">
+                                    <i class="fas fa-arrow-up"></i>
+                                    <span>+0.22</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Portfolio Tab -->
+        <div class="tab-content" id="portfolio">
+            <div class="portfolio-grid">
+                <!-- Allocation Recommendations -->
+                <div class="panel allocation-panel">
+                    <div class="panel-header">
+                        <h3>포트폴리오 배분 권장안</h3>
+                        <div class="allocation-type-selector">
+                            <button class="allocation-btn active" data-type="conservative">보수형</button>
+                            <button class="allocation-btn" data-type="balanced">균형형</button>
+                            <button class="allocation-btn" data-type="aggressive">공격형</button>
+                        </div>
+                    </div>
+                    <div class="panel-content">
+                        <div class="allocation-chart-container">
+                            <canvas id="allocationChart"></canvas>
+                        </div>
+                        <div class="allocation-details">
+                            <div class="allocation-type active" id="conservative-allocation">
+                                <h4>보수형 포트폴리오</h4>
+                                <div class="allocation-list">
+                                    <div class="allocation-item">
+                                        <span class="ticker">RMD</span>
+                                        <span class="allocation-bar">
+                                            <span class="fill" style="width: 40%"></span>
+                                        </span>
+                                        <span class="percentage">40%</span>
+                                    </div>
+                                    <div class="allocation-item">
+                                        <span class="ticker">ABT</span>
+                                        <span class="allocation-bar">
+                                            <span class="fill" style="width: 35%"></span>
+                                        </span>
+                                        <span class="percentage">35%</span>
+                                    </div>
+                                    <div class="allocation-item">
+                                        <span class="ticker">TRMB</span>
+                                        <span class="allocation-bar">
+                                            <span class="fill" style="width: 15%"></span>
+                                        </span>
+                                        <span class="percentage">15%</span>
+                                    </div>
+                                    <div class="allocation-item">
+                                        <span class="ticker">EW</span>
+                                        <span class="allocation-bar">
+                                            <span class="fill" style="width: 10%"></span>
+                                        </span>
+                                        <span class="percentage">10%</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Performance Attribution -->
+                <div class="panel performance-attribution">
+                    <div class="panel-header">
+                        <h3>성과 기여도 분석</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="chart-container">
+                            <canvas id="attributionChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Correlation Matrix -->
+                <div class="panel correlation-matrix">
+                    <div class="panel-header">
+                        <h3>상관관계 매트릭스</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="correlation-heatmap">
+                            <table class="correlation-table">
+                                <thead>
+                                    <tr>
+                                        <th></th>
+                                        <th>RMD</th>
+                                        <th>TRMB</th>
+                                        <th>ABT</th>
+                                        <th>EW</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th>RMD</th>
+                                        <td class="corr-cell perfect">1.00</td>
+                                        <td class="corr-cell low">0.23</td>
+                                        <td class="corr-cell medium">0.42</td>
+                                        <td class="corr-cell medium">0.38</td>
+                                    </tr>
+                                    <tr>
+                                        <th>TRMB</th>
+                                        <td class="corr-cell low">0.23</td>
+                                        <td class="corr-cell perfect">1.00</td>
+                                        <td class="corr-cell low">0.31</td>
+                                        <td class="corr-cell low">0.19</td>
+                                    </tr>
+                                    <tr>
+                                        <th>ABT</th>
+                                        <td class="corr-cell medium">0.42</td>
+                                        <td class="corr-cell low">0.31</td>
+                                        <td class="corr-cell perfect">1.00</td>
+                                        <td class="corr-cell high">0.67</td>
+                                    </tr>
+                                    <tr>
+                                        <th>EW</th>
+                                        <td class="corr-cell medium">0.38</td>
+                                        <td class="corr-cell low">0.19</td>
+                                        <td class="corr-cell high">0.67</td>
+                                        <td class="corr-cell perfect">1.00</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Rebalancing Triggers -->
+                <div class="panel rebalancing-triggers">
+                    <div class="panel-header">
+                        <h3>리밸런싱 트리거</h3>
+                    </div>
+                    <div class="panel-content">
+                        <div class="trigger-list">
+                            <div class="trigger-item">
+                                <div class="trigger-icon warning">
+                                    <i class="fas fa-exclamation-triangle"></i>
+                                </div>
+                                <div class="trigger-content">
+                                    <div class="trigger-title">RMD 비중 초과</div>
+                                    <div class="trigger-description">현재 42%, 목표 40% (2% 초과)</div>
+                                </div>
+                                <div class="trigger-action">
+                                    <button class="btn-small">조정</button>
+                                </div>
+                            </div>
+                            <div class="trigger-item">
+                                <div class="trigger-icon success">
+                                    <i class="fas fa-check-circle"></i>
+                                </div>
+                                <div class="trigger-content">
+                                    <div class="trigger-title">밸런스 양호</div>
+                                    <div class="trigger-description">다른 종목들은 목표 범위 내</div>
+                                </div>
+                                <div class="trigger-action">
+                                    <span class="status-ok">정상</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Scripts -->
+    <script src="app.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+
+    const chartData = {
+        weightedScores: {
+            labels: ['EW', 'ABT', 'TRMB', 'RMD'],
+            scores: [74.4, 79.4, 80.9, 89.5]
+        },
+        competencies: {
+            labels: [
+                '저평가', '성장성', '경기 방어력', '가격 결정력', '전략적 해자',
+
+                '혁신 파이프라인', '시장 지위', '경영진 역량', '자본 효율성', '현금 흐름',
+                '재무 건전성', '주주 환원', 'ESG', '시장 심리', '거시 환경'
+            ],
+            datasets: [
+                {
+                    label: 'RMD',
+                    data: [5, 8, 9, 9, 9, 7, 9, 8, 9, 8, 7, 5, 6, 5, 5],
+                    borderColor: '#58A6FF',
+                    backgroundColor: 'rgba(88, 166, 255, 0.2)',
+                },
+                {
+                    label: 'TRMB',
+                    data: [7, 7, 5, 6, 7, 8, 7, 7, 6, 7, 6, 5, 5, 5, 6],
+                    borderColor: '#3FB950',
+                    backgroundColor: 'rgba(63, 185, 80, 0.2)',
+                },
+                {
+                    label: 'ABT',
+                    data: [5, 6, 8, 7, 8, 7, 8, 7, 7, 6, 8, 7, 6, 4, 4],
+                    borderColor: '#FDB839',
+                    backgroundColor: 'rgba(253, 184, 57, 0.2)',
+                },
+                {
+                    label: 'EW',
+                    data: [4, 7, 6, 7, 8, 6, 8, 6, 6, 6, 7, 4, 5, 6, 3],
+                    borderColor: '#F85149',
+                    backgroundColor: 'rgba(248, 81, 73, 0.2)',
+                }
+            ]
+        },
+        scenarios: {
+            labels: ['EW', 'ABT', 'TRMB', 'RMD'],
+            datasets: [
+                {
+                    label: '기대수익률 범위',
+                    data: [[-8, 15], [-2, 15], [-5, 22], [0, 25]],
+                    backgroundColor: '#161B22',
+                    borderColor: '#58A6FF',
+                    borderWidth: 1,
+                    borderSkipped: false,
+                }
+            ],
+            sp500_benchmark: 5
+        }
+    };
+
+    const globalChartOptions = {
+        maintainAspectRatio: false,
+        responsive: true,
+        plugins: {
+            legend: {
+                labels: {
+                    color: '#C9D1D9',
+                    font: { family: "'Noto Sans KR', sans-serif" }
+                }
+            },
+            tooltip: {
+                titleFont: { family: "'Noto Sans KR', sans-serif" },
+                bodyFont: { family: "'Noto Sans KR', sans-serif" },
+                callbacks: {
+                    title: function(tooltipItems) {
+                        const item = tooltipItems[0];
+                        let label = item.chart.data.labels[item.dataIndex];
+                        if (Array.isArray(label)) {
+                            return label.join(' ');
+                        }
+                        return label;
+                    }
+                }
+            }
+        },
+        scales: {
+            x: {
+                ticks: { color: '#8B949E' },
+                grid: { color: 'rgba(48, 54, 61, 0.5)' }
+            },
+            y: {
+                ticks: { color: '#8B949E' },
+                grid: { color: 'rgba(48, 54, 61, 0.5)' }
+            }
+        }
+    };
+
+    const renderWeightedScoreChart = () => {
+        const ctx = document.getElementById('weightedScoreChart');
+        if (!ctx) return;
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: chartData.weightedScores.labels,
+                datasets: [{
+                    label: '최종 가중 점수',
+                    data: chartData.weightedScores.scores,
+                    backgroundColor: [
+                        'rgba(248, 81, 73, 0.7)',
+                        'rgba(253, 184, 57, 0.7)',
+                        'rgba(63, 185, 80, 0.7)',
+                        'rgba(88, 166, 255, 0.7)'
+                    ],
+                    borderColor: [
+                        '#F85149',
+                        '#FDB839',
+                        '#3FB950',
+                        '#58A6FF'
+                    ],
+                    borderWidth: 1
+                }]
+            },
+            options: { ...globalChartOptions,
+                indexAxis: 'y',
+                plugins: { ...globalChartOptions.plugins,
+                    legend: { display: false },
+                    title: { display: false }
+                },
+                scales: {
+                     x: { ...globalChartOptions.scales.x, suggestedMin: 50 },
+                     y: { ...globalChartOptions.scales.y, ticks: { ...globalChartOptions.scales.y.ticks, font: { size: 14, weight: 'bold' } } }
+                }
+            }
+        });
+    };
+
+    const renderRadarChart = () => {
+        const ctx = document.getElementById('competencyRadarChart');
+        if (!ctx) return;
+        new Chart(ctx, {
+            type: 'radar',
+            data: chartData.competencies,
+            options: { ...globalChartOptions,
+                plugins: {
+                    ...globalChartOptions.plugins,
+                     legend: { position: 'bottom' }
+                },
+                scales: {
+                    r: {
+                        angleLines: { color: 'rgba(48, 54, 61, 0.8)' },
+                        grid: { color: 'rgba(48, 54, 61, 0.8)' },
+                        pointLabels: { color: '#C9D1D9', font: { size: 10 } },
+                        ticks: {
+                            color: '#0D1117',
+                            backdropColor: 'rgba(139, 148, 158, 0.8)',
+                            stepSize: 2
+                        },
+                        suggestedMin: 0,
+                        suggestedMax: 10
+                    }
+                }
+            }
+        });
+    };
+
+    const renderScenarioChart = () => {
+        const ctx = document.getElementById('scenarioChartDeepDive');
+        if (!ctx) return;
+        new Chart(ctx, {
+            type: 'bar',
+            data: chartData.scenarios,
+            options: {
+                ...globalChartOptions,
+                indexAxis: 'y',
+                 plugins: {
+                    ...globalChartOptions.plugins,
+                    legend: { display: false },
+                    tooltip: {
+                        ...globalChartOptions.plugins.tooltip,
+                        callbacks: {
+                            label: function(context) {
+                                const raw = context.raw;
+                                return `수익률 범위: ${raw[0]}% ~ ${raw[1]}%`;
+                            },
+                             ...globalChartOptions.plugins.tooltip.callbacks
+                        }
+                    },
+                    annotation: {
+                        annotations: {
+                            line1: {
+                                type: 'line',
+                                xMin: chartData.sp500_benchmark,
+                                xMax: chartData.sp500_benchmark,
+                                borderColor: '#FDB839',
+                                borderWidth: 2,
+                                borderDash: [6, 6],
+                                label: {
+                                    content: 'S&P 500 예상(' + chartData.sp500_benchmark + '%)',
+                                    display: true,
+                                    position: 'start',
+                                    color: '#FDB839',
+                                    backgroundColor: 'rgba(13, 17, 23, 0.8)',
+                                    font: { family: "'Noto Sans KR', sans-serif" }
+                                }
+                            }
+                        }
+                    }
+                },
+                scales: {
+                     x: { ...globalChartOptions.scales.x,
+                        title: { display: true, text: '기대 수익률 (%)', color: '#8B949E' }
+                     },
+                     y: { ...globalChartOptions.scales.y,
+                        ticks: { ...globalChartOptions.scales.y.ticks, font: { size: 14, weight: 'bold' } }
+                     }
+                }
+            }
+        });
+    };
+
+    const setupScrollAnimations = () => {
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                }
+            });
+        }, { threshold: 0.1 });
+
+        document.querySelectorAll('.scroll-fade-in').forEach(el => {
+            observer.observe(el);
+        });
+    };
+
+    const setupScrollspy = () => {
+        const sections = document.querySelectorAll('.scroll-section');
+        const navLinks = document.querySelectorAll('#side-nav .nav-link');
+
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    const id = entry.target.getAttribute('id');
+                    navLinks.forEach(link => {
+                        link.classList.remove('active');
+                        if (link.getAttribute('href') === `#${id}`) {
+                            link.classList.add('active');
+                        }
+                    });
+                }
+            });
+        }, { rootMargin: '-30% 0px -60% 0px' });
+
+        sections.forEach(section => observer.observe(section));
+
+        navLinks.forEach(anchor => {
+            anchor.addEventListener('click', function(e) {
+                e.preventDefault();
+                document.querySelector(this.getAttribute('href')).scrollIntoView({
+                    behavior: 'smooth'
+                });
+            });
+        });
+    };
+
+    const setupFlipCards = () => {
+        document.querySelectorAll('.flip-card').forEach(card => {
+            card.addEventListener('click', () => card.classList.toggle('is-active'));
+        });
+    };
+
+    try {
+        renderWeightedScoreChart();
+        renderRadarChart();
+    } catch (e) { console.error("Chart rendering failed:", e); }
+
+    // Annotation plugin is not standard in Chart.js, so we wrap its usage
+    try {
+        // Mock ChartJS-Plugin-Annotation if not present
+        if(typeof Chart.registry.plugins.get('annotation') === 'undefined'){
+            Chart.register({ id: 'annotation', beforeDraw: () => {} });
+        }
+        renderScenarioChart();
+    } catch (e) { console.error("Scenario chart with annotation failed. Annotation plugin might be missing.", e); }
+
+    setupScrollAnimations();
+    setupScrollspy();
+    setupFlipCards();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `integrated_alpha_pick.html` using dashboard layout
- merge styles and scripts from the original deep-dive page
- embed hero, comparison, scenario, deep-dive and conclusion sections
- preserve scrollspy and interactive charts

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_686153b0712c8329ba447c9fb0a44e76