### PR TITLE
Add 종합 판단 매트릭스 section

### DIFF
--- a/preview/posts/2025-06-23_Alpha_Pick_RMD/integrated_alpha_pick.html
+++ b/preview/posts/2025-06-23_Alpha_Pick_RMD/integrated_alpha_pick.html
@@ -431,6 +431,44 @@
                 </div>
             </section>
 
+            <section id="decision-matrix" class="mb-24 scroll-section">
+                <h2 class="text-3xl font-bold text-center text-white mb-4">종합 판단 매트릭스</h2>
+                <p class="text-center text-gray-400 mb-12 max-w-2xl mx-auto">각 기업에 대한 최종 평가를 한눈에 요약합니다.</p>
+                <div class="glass-card rounded-xl p-6 scroll-fade-in">
+                    <table class="judgment-table">
+                        <thead>
+                            <tr>
+                                <th>티커</th>
+                                <th>종합 점수</th>
+                                <th>판단</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="highlight">
+                                <td>RMD</td>
+                                <td>89.5</td>
+                                <td>최종 추천 (Top Pick)</td>
+                            </tr>
+                            <tr>
+                                <td>TRMB</td>
+                                <td>80.9</td>
+                                <td>2순위 (Runner-up)</td>
+                            </tr>
+                            <tr>
+                                <td>ABT</td>
+                                <td>79.4</td>
+                                <td>안정적 선택지</td>
+                            </tr>
+                            <tr>
+                                <td>EW</td>
+                                <td>74.4</td>
+                                <td>잠재적 다크호스</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
             <section id="conclusion" class="scroll-section">
                 <h2 class="text-3xl font-bold text-center text-white mb-4">결론 및 리스크 요인</h2>
                 <p class="text-center text-gray-400 mb-12 max-w-2xl mx-auto">최종 투자 추천을 다시 한번 강조하며, 성공적인 투자를 위해 반드시 고려해야 할 잠재적 리스크 요인을 제시합니다.</p>

--- a/preview/posts/2025-06-23_Alpha_Pick_RMD/style.css
+++ b/preview/posts/2025-06-23_Alpha_Pick_RMD/style.css
@@ -1450,6 +1450,32 @@ body {
   color: var(--danger-red);
 }
 
+/* Judgment Matrix */
+.judgment-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.judgment-table th,
+.judgment-table td {
+  padding: 12px;
+  text-align: center;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.judgment-table th {
+  background: rgba(255, 255, 255, 0.05);
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 13px;
+  text-transform: uppercase;
+}
+
+.judgment-table .highlight {
+  background: rgba(0, 122, 255, 0.1);
+}
+
 /* Export Button */
 .export-btn {
   display: flex;


### PR DESCRIPTION
## Summary
- add a new "종합 판단 매트릭스" section in the integrated alpha pick page
- style the judgment matrix table and highlight the RMD row

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6861e4fac4c48329b331653cd0028f15