### PR TITLE
Centralize baseHref for all SPA pages

### DIFF
--- a/100x/daily-wrap/100x-daily-wrap-template.html
+++ b/100x/daily-wrap/100x-daily-wrap-template.html
@@ -31,6 +31,7 @@
 		} else {
 		baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
 		}
+        window.baseHref = baseHref;
 		
 		// 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
 		if (!document.querySelector('base')) {
@@ -1107,9 +1108,9 @@
             navScript.innerHTML = `
                 이 부분은 상위 폴더의 네비게이션 파일을 로드하는 스크립트입니다.
                 로컬 환경이나 다른 서버 구조에서는 경로 수정이 필요할 수 있습니다.
-                import { siteVersion } from '../../version.js';
+                const { siteVersion } = await import(`${window.baseHref}version.js`);
                 if (window.top === window.self) {
-                    fetch(\`../../nav.html?v=\${siteVersion}\`)
+                    fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                         .then(r => r.text())
                         .then(html => {
                             const nav = document.getElementById('nav');

--- a/100x/daily-wrap/2025-06-21_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-21_100x-daily-wrap.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./2025-06-21_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap: June 21, 2025 (Layout Fixed Version)">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
@@ -479,9 +480,9 @@ false} } }
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/100x/daily-wrap/2025-06-24_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-24_100x-daily-wrap.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./2025-06-24_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 24일 (차트 수정)">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- Chart.js 데이터 레이블 플러그인 추가 -->
@@ -940,9 +941,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/100x/daily-wrap/2025-06-25_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-25_100x-daily-wrap.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./2025-06-25_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 25일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
@@ -559,9 +560,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
@@ -51,6 +51,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -68,7 +69,7 @@
     <link rel="canonical" href="./2025-06-26_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 26일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <!-- 외부 라이브러리: Tailwind(스타일), Chart.js(차트), FontAwesome(아이콘) -->
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -519,9 +520,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
@@ -76,6 +76,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -95,7 +96,7 @@
     <link rel="canonical" href="./2025-06-27_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 27일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <!-- 외부 라이브러리: Tailwind(스타일), Chart.js(차트), FontAwesome(아이콘) -->
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -626,9 +627,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
@@ -55,6 +55,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -72,7 +73,7 @@
     <link rel="canonical" href="./2025-06-28_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 28일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <!-- 외부 라이브러리: Tailwind(스타일), Chart.js(차트), FontAwesome(아이콘) -->
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -627,9 +628,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/100x/daily-wrap/2025-07-01_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-07-01_100x-daily-wrap.html
@@ -55,6 +55,7 @@
 		} else {
 		baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
 		}
+        window.baseHref = baseHref;
 		
 		// 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
 		if (!document.querySelector('base')) {
@@ -72,7 +73,7 @@
     <link rel="canonical" href="./2025-07-01_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 7월 1일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <style>
         body { font-family: 'Noto Sans KR', 'Roboto', sans-serif; }
@@ -1509,9 +1510,9 @@
             const navScript = document.createElement('script');
             navScript.type = 'module';
             navScript.innerHTML = `
-                import { siteVersion } from '../../version.js';
+                const { siteVersion } = await import(`${window.baseHref}version.js`);
                 if (window.top === window.self) {
-                    fetch(\`../../nav.html?v=\${siteVersion}\`)
+                    fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                         .then(r => r.text())
                         .then(html => {
                             const nav = document.getElementById('nav');

--- a/100x/daily-wrap/2025-07-02_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-07-02_100x-daily-wrap.html
@@ -38,7 +38,7 @@
     <link rel="canonical" href="./2025-07-02_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 7월 2일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <style>
         body { font-family: 'Noto Sans KR', 'Roboto', sans-serif; }
@@ -1418,9 +1418,9 @@
             const navScript = document.createElement('script');
             navScript.type = 'module';
             navScript.innerHTML = `
-                import { siteVersion } from '../../version.js';
+                const { siteVersion } = await import(`${window.baseHref}version.js`);
                 if (window.top === window.self) {
-                    fetch(\`../../nav.html?v=\${siteVersion}\`)
+                    fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                         .then(r => r.text())
                         .then(html => {
                             const nav = document.getElementById('nav');

--- a/100x/index.html
+++ b/100x/index.html
@@ -57,6 +57,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -74,7 +75,7 @@
     <link rel="canonical" href="./index.html">
     <meta property="og:title" content="100x Daily Wrap - El Fenomeno Kim">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../favicon-96x96.png">
+    <meta property="og:image" content=\"favicon-96x96.png\">
     <meta name="theme-color" content="#0ea5e9">
     <style>
         * { font-family: 'Noto Sans KR', sans-serif; }
@@ -261,9 +262,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(res => res.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/404.html
+++ b/404.html
@@ -20,6 +20,7 @@
       } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
       }
+        window.baseHref = baseHref;
       
       // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
       if (!document.querySelector('base')) {

--- a/ib/ib-total-guide-calculator.html
+++ b/ib/ib-total-guide-calculator.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./ib-total-guide-calculator.html">
     <meta property="og:title" content="무한매수법 완전정복 인포그래픽 (API 연동 최종본)">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../favicon-96x96.png">
+    <meta property="og:image" content=\"favicon-96x96.png\">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- 
@@ -546,9 +547,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@ LLM_GUIDE_END -->
         } else {
           baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -123,7 +124,7 @@ LLM_GUIDE_END -->
 
     <script type="module">
         /* ──────────────── 설정 상수 ──────────────── */
-        import { siteVersion } from './version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
 
         // const navFrame     = document.getElementById('nav-frame');
         const navContainer = document.getElementById('nav');
@@ -131,7 +132,7 @@ LLM_GUIDE_END -->
 
         document.addEventListener('DOMContentLoaded', () => {
             // 🚀 Nav를 fetch로 로드 (멀티차트와 동일한 방식)
-            fetch(`nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     navContainer.innerHTML = html;

--- a/main.html
+++ b/main.html
@@ -20,6 +20,7 @@
       } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
       }
+        window.baseHref = baseHref;
       
       // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
       if (!document.querySelector('base')) {
@@ -204,9 +205,9 @@
         </div>
   </footer>
 <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/nav.html
+++ b/nav.html
@@ -20,6 +20,7 @@
       } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
       }
+        window.baseHref = baseHref;
       
       // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
       if (!document.querySelector('base')) {

--- a/posts/2025-06-22_playbook.html
+++ b/posts/2025-06-22_playbook.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./2025-06-22_playbook.html">
     <meta property="og:title" content="미국의 새로운 플레이북: 국가 자본주의와 스테이블코인 전략">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../favicon-96x96.png">
+    <meta property="og:image" content=\"favicon-96x96.png\">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!--
@@ -656,9 +657,9 @@
 
     </script>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
+++ b/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./2025-06-23_stablecoin-revolution-complete-masterplan.html">
     <meta property="og:title" content="스테이블코인 마스터플랜: 디지털 시대 달러 패권의 완전 설계도">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../favicon-96x96.png">
+    <meta property="og:image" content=\"favicon-96x96.png\">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
@@ -757,9 +758,9 @@
         </div>
     </footer>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(res => res.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/posts/2025-06-30_Alpha_Pick_RMD/index.html
+++ b/posts/2025-06-30_Alpha_Pick_RMD/index.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {

--- a/posts/index.html
+++ b/posts/index.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./index.html">
     <meta property="og:title" content="분석 아카이브 - El Fenomeno">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../favicon-96x96.png">
+    <meta property="og:image" content=\"favicon-96x96.png\">
     <meta name="theme-color" content="#3b82f6">
     <style>
         body {
@@ -167,9 +168,9 @@
         </div>
     </footer>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(res => res.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/100x/daily-wrap/2025-06-21_100x-daily-wrap.html
+++ b/preview/100x/daily-wrap/2025-06-21_100x-daily-wrap.html
@@ -11,7 +11,7 @@
     <link rel="canonical" href="./2025-06-21_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap: June 21, 2025 (Layout Fixed Version)">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
@@ -453,9 +453,9 @@ false} } }
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/100x/daily-wrap/2025-06-24_100x-daily-wrap.html
+++ b/preview/100x/daily-wrap/2025-06-24_100x-daily-wrap.html
@@ -11,7 +11,7 @@
     <link rel="canonical" href="./2025-06-24_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 24일 (차트 수정)">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- Chart.js 데이터 레이블 플러그인 추가 -->
@@ -914,9 +914,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/100x/daily-wrap/2025-06-25_100x-daily-wrap.html
+++ b/preview/100x/daily-wrap/2025-06-25_100x-daily-wrap.html
@@ -11,7 +11,7 @@
     <link rel="canonical" href="./2025-06-25_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 25일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
@@ -533,9 +533,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
+++ b/preview/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
@@ -42,7 +42,7 @@
     <link rel="canonical" href="./2025-06-26_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 26일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <!-- 외부 라이브러리: Tailwind(스타일), Chart.js(차트), FontAwesome(아이콘) -->
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -493,9 +493,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
+++ b/preview/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
@@ -69,7 +69,7 @@
     <link rel="canonical" href="./2025-06-27_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 27일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <!-- 외부 라이브러리: Tailwind(스타일), Chart.js(차트), FontAwesome(아이콘) -->
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -600,9 +600,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
+++ b/preview/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
@@ -46,7 +46,7 @@
     <link rel="canonical" href="./2025-06-28_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 6월 28일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <!-- 외부 라이브러리: Tailwind(스타일), Chart.js(차트), FontAwesome(아이콘) -->
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -601,9 +601,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/100x/daily-wrap/2025-07-01_100x-daily-wrap.html
+++ b/preview/100x/daily-wrap/2025-07-01_100x-daily-wrap.html
@@ -46,7 +46,7 @@
     <link rel="canonical" href="./2025-07-01_100x-daily-wrap.html">
     <meta property="og:title" content="100x Daily Wrap - 2025년 7월 1일">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../../favicon-96x96.png"> 
+    <meta property="og:image" content="favicon-96x96.png"> 
     <meta name="theme-color" content="#0ea5e9">
     <style>
         body { font-family: 'Noto Sans KR', 'Roboto', sans-serif; }
@@ -1483,9 +1483,9 @@
             const navScript = document.createElement('script');
             navScript.type = 'module';
             navScript.innerHTML = `
-                import { siteVersion } from '../../version.js';
+                const { siteVersion } = await import(`${window.baseHref}version.js`);
                 if (window.top === window.self) {
-                    fetch(\`../../nav.html?v=\${siteVersion}\`)
+                    fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                         .then(r => r.text())
                         .then(html => {
                             const nav = document.getElementById('nav');

--- a/preview/100x/index.html
+++ b/preview/100x/index.html
@@ -57,6 +57,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -74,7 +75,7 @@
     <link rel="canonical" href="./index.html">
     <meta property="og:title" content="100x Daily Wrap - El Fenomeno Kim">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <style>
         * { font-family: 'Noto Sans KR', sans-serif; }
@@ -261,9 +262,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(res => res.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/404.html
+++ b/preview/404.html
@@ -20,6 +20,7 @@
       } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
       }
+        window.baseHref = baseHref;
       
       // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
       if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
   <link rel="canonical" href="./404.html">
   <meta property="og:title" content="404 - Page Not Found">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="../favicon-96x96.png">
+  <meta property="og:image" content=\"favicon-96x96.png\">
   <meta name="theme-color" content="#0ea5e9">
   <style>
     body {font-family: 'Noto Sans KR', sans-serif;}

--- a/preview/ib/ib-total-guide-calculator.html
+++ b/preview/ib/ib-total-guide-calculator.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./ib-total-guide-calculator.html">
     <meta property="og:title" content="무한매수법 완전정복 인포그래픽 (API 연동 최종본)">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- 
@@ -546,9 +547,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/index.html
+++ b/preview/index.html
@@ -75,6 +75,7 @@ LLM_GUIDE_END -->
         } else {
           baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -92,7 +93,7 @@ LLM_GUIDE_END -->
     <link rel="canonical" href="./index.html">
     <meta property="og:title" content="100x FenoK">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../favicon-96x96.png">
+    <meta property="og:image" content=\"favicon-96x96.png\">
     <meta name="theme-color" content="#0ea5e9">
 
     <link rel="icon" type="image/x-icon" href="./favicon.ico">
@@ -123,7 +124,7 @@ LLM_GUIDE_END -->
 
     <script type="module">
         /* ──────────────── 설정 상수 ──────────────── */
-        import { siteVersion } from './version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
 
         // const navFrame     = document.getElementById('nav-frame');
         const navContainer = document.getElementById('nav');
@@ -131,7 +132,7 @@ LLM_GUIDE_END -->
 
         document.addEventListener('DOMContentLoaded', () => {
             // 🚀 Nav를 fetch로 로드 (멀티차트와 동일한 방식)
-            fetch(`nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     navContainer.innerHTML = html;

--- a/preview/main.html
+++ b/preview/main.html
@@ -20,6 +20,7 @@
       } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
       }
+        window.baseHref = baseHref;
       
       // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
       if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
   <link rel="canonical" href="./main.html">
   <meta property="og:title" content="FenoK · Investment Knowledge">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="../favicon-96x96.png">
+  <meta property="og:image" content=\"favicon-96x96.png\">
   <meta name="theme-color" content="#0ea5e9">
   <style>
     /* 기본 폰트 및 커스텀 스타일 설정 */
@@ -204,9 +205,9 @@
         </div>
   </footer>
 <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/nav.html
+++ b/preview/nav.html
@@ -20,6 +20,7 @@
       } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
       }
+        window.baseHref = baseHref;
       
       // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
       if (!document.querySelector('base')) {
@@ -36,7 +37,7 @@
   <link rel="canonical" href="./nav.html">
   <meta property="og:title" content="FenoK Navigation">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="../favicon-96x96.png">
+  <meta property="og:image" content=\"favicon-96x96.png\">
   <meta name="theme-color" content="#0ea5e9">
   <style>
     *{font-family:'Noto Sans KR',sans-serif}

--- a/preview/posts/2025-06-22_playbook.html
+++ b/preview/posts/2025-06-22_playbook.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./2025-06-22_playbook.html">
     <meta property="og:title" content="미국의 새로운 플레이북: 국가 자본주의와 스테이블코인 전략">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!--
@@ -656,9 +657,9 @@
 
     </script>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
+++ b/preview/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./2025-06-23_stablecoin-revolution-complete-masterplan.html">
     <meta property="og:title" content="스테이블코인 마스터플랜: 디지털 시대 달러 패권의 완전 설계도">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
@@ -757,9 +758,9 @@
         </div>
     </footer>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(res => res.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/posts/2025-06-30_Alpha_Pick_RMD/index.html
+++ b/preview/posts/2025-06-30_Alpha_Pick_RMD/index.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {

--- a/preview/posts/index.html
+++ b/preview/posts/index.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./index.html">
     <meta property="og:title" content="분석 아카이브 - El Fenomeno">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#3b82f6">
     <style>
         body {
@@ -167,9 +168,9 @@
         </div>
     </footer>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(res => res.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/tools/asset/multichart.html
+++ b/preview/tools/asset/multichart.html
@@ -20,6 +20,7 @@
       } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
       }
+        window.baseHref = baseHref;
       
       // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
       if (!document.querySelector('base')) {
@@ -31,7 +32,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Noto+Sans+KR:wght@500;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
     const cfg = document.createElement('script');
     cfg.defer = true;
     cfg.type = 'module';
@@ -45,7 +46,7 @@
   <link rel="canonical" href="./multichart.html">
   <meta property="og:title" content="100x 멀티차트 (최종 안정판)">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="../../../favicon-96x96.png">
+  <meta property="og:image" content="favicon-96x96.png">
   <meta name="theme-color" content="#0ea5e9">
 
   <!-- 스타일 & 라이브러리 (기존과 동일) -->
@@ -521,9 +522,9 @@ async function fetchPriceDataAlpha(symbol) {
 </script>
 <!-- === override end === -->
 <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/vr/index.html
+++ b/preview/vr/index.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./index.html">
     <meta property="og:title" content="VR 시스템 아카이브 - El Fenomeno">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <style>
         body {
@@ -251,9 +252,9 @@
             </p>
 </div>
 <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/vr/vr-complete-system.html
+++ b/preview/vr/vr-complete-system.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./vr-complete-system.html">
     <meta property="og:title" content="밸류 리밸런싱(VR) 5.0 최종 마스터 가이드 (통합 완성본 v3.0)">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
@@ -575,9 +576,9 @@
     });
 </script>
 <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/preview/vr/vr-total-guide-calculator.html
+++ b/preview/vr/vr-total-guide-calculator.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./vr-total-guide-calculator.html">
     <meta property="og:title" content="밸류 리밸런싱 토탈 가이드 & 계산기">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../../favicon-96x96.png">
+    <meta property="og:image" content="favicon-96x96.png">
     <meta name="theme-color" content="#0ea5e9">
     <!-- KaTeX for beautiful math rendering -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" xintegrity="sha384-n8MVd4RsNIU0KOVEMVIARBEKsPDc1Cwo9zMBRIms/NOTBkfLe2i9cwWdLLH4OztO" crossorigin="anonymous">
@@ -490,9 +491,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/tools/asset/multichart.html
+++ b/tools/asset/multichart.html
@@ -20,6 +20,7 @@
       } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
       }
+        window.baseHref = baseHref;
       
       // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
       if (!document.querySelector('base')) {
@@ -31,7 +32,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Noto+Sans+KR:wght@500;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="module">
-        import { siteVersion } from '../../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
     const cfg = document.createElement('script');
     cfg.defer = true;
     cfg.type = 'module';
@@ -45,7 +46,7 @@
   <link rel="canonical" href="./multichart.html">
   <meta property="og:title" content="100x 멀티차트 (최종 안정판)">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="../../favicon-96x96.png">
+  <meta property="og:image" content="favicon-96x96.png">
   <meta name="theme-color" content="#0ea5e9">
 
   <!-- 스타일 & 라이브러리 (기존과 동일) -->
@@ -521,9 +522,9 @@ async function fetchPriceDataAlpha(symbol) {
 </script>
 <!-- === override end === -->
 <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/vr/index.html
+++ b/vr/index.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./index.html">
     <meta property="og:title" content="VR 시스템 아카이브 - El Fenomeno">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../favicon-96x96.png">
+    <meta property="og:image" content=\"favicon-96x96.png\">
     <meta name="theme-color" content="#0ea5e9">
     <style>
         body {
@@ -251,9 +252,9 @@
             </p>
 </div>
 <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/vr/vr-complete-system.html
+++ b/vr/vr-complete-system.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./vr-complete-system.html">
     <meta property="og:title" content="밸류 리밸런싱(VR) 5.0 최종 마스터 가이드 (통합 완성본 v3.0)">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../favicon-96x96.png">
+    <meta property="og:image" content=\"favicon-96x96.png\">
     <meta name="theme-color" content="#0ea5e9">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
@@ -575,9 +576,9 @@
     });
 </script>
 <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');

--- a/vr/vr-total-guide-calculator.html
+++ b/vr/vr-total-guide-calculator.html
@@ -20,6 +20,7 @@
         } else {
         baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
         }
+        window.baseHref = baseHref;
         
         // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
         if (!document.querySelector('base')) {
@@ -37,7 +38,7 @@
     <link rel="canonical" href="./vr-total-guide-calculator.html">
     <meta property="og:title" content="밸류 리밸런싱 토탈 가이드 & 계산기">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="../favicon-96x96.png">
+    <meta property="og:image" content=\"favicon-96x96.png\">
     <meta name="theme-color" content="#0ea5e9">
     <!-- KaTeX for beautiful math rendering -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" xintegrity="sha384-n8MVd4RsNIU0KOVEMVIARBEKsPDc1Cwo9zMBRIms/NOTBkfLe2i9cwWdLLH4OztO" crossorigin="anonymous">
@@ -490,9 +491,9 @@
         });
     </script>
     <script type="module">
-        import { siteVersion } from '../version.js';
+        const { siteVersion } = await import(`${window.baseHref}version.js`);
         if (window.top === window.self) {
-            fetch(`../nav.html?v=${siteVersion}`)
+            fetch(`${window.baseHref}nav.html?v=${siteVersion}`)
                 .then(r => r.text())
                 .then(html => {
                     const nav = document.getElementById('nav');


### PR DESCRIPTION
## Summary
- expose computed `baseHref` as `window.baseHref`
- load `version.js` via dynamic import
- build nav URLs with `window.baseHref`
- rely on `<base>` for favicon/manifest links
- mirror changes in preview files

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_686762de4024832987c54c96f2483d86