### PR TITLE
Add reusable loadPage module

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,7 @@ LLM_GUIDE_END --><!-- ───────────────────�
 
     <script type="module">const { siteVersion } = await import(`${window.baseHref}version.js`);
 const { loadNav } = await import(`${window.baseHref}loadNav.js`);
+const { loadPage } = await import(`${window.baseHref}loadPage.js`);
 if (window.top === window.self) {
     await loadNav(siteVersion);
     loadPage('main.html');

--- a/loadPage.js
+++ b/loadPage.js
@@ -1,0 +1,21 @@
+import { siteVersion } from './version.js';
+
+export function loadPage(pageUrl) {
+  const isAbsolute = /^(?:[a-z]+:)?\/\//i.test(pageUrl) || pageUrl.startsWith(window.baseHref);
+  const resolved = isAbsolute ? pageUrl : window.baseHref + pageUrl;
+  const fullUrl = `${resolved}?v=${siteVersion}`;
+  document.getElementById('content-frame').src = fullUrl;
+
+  const normalize = url => url.replace(window.baseHref, '').replace(/^\.\//, '');
+  const target = normalize(pageUrl);
+
+  document.querySelectorAll('#nav a[data-path]').forEach(a => {
+    const isActive = normalize(a.getAttribute('data-path')) === target;
+    a.classList.toggle('text-blue-600', isActive);
+    a.classList.toggle('font-bold', isActive);
+    a.classList.toggle('text-slate-600', !isActive);
+    a.classList.toggle('font-medium', !isActive);
+  });
+}
+
+window.loadPage = loadPage;

--- a/nav.html
+++ b/nav.html
@@ -88,7 +88,7 @@
   <script>
     document.querySelectorAll('a[data-path]').forEach(a => {
       a.addEventListener('click', e => {
-        const target = a.getAttribute('href');
+        const target = a.getAttribute('data-path');
 
         // --- 핵심 수정 로직 ---
         // 1. 현재 페이지가 iframe 안에서 실행되었고,

--- a/preview/index.html
+++ b/preview/index.html
@@ -118,6 +118,7 @@ LLM_GUIDE_END --><!-- ───────────────────�
 
     <script type="module">const { siteVersion } = await import(`${window.baseHref}version.js`);
 const { loadNav } = await import(`${window.baseHref}loadNav.js`);
+const { loadPage } = await import(`${window.baseHref}loadPage.js`);
 if (window.top === window.self) {
     await loadNav(siteVersion);
     loadPage('main.html');

--- a/preview/nav.html
+++ b/preview/nav.html
@@ -88,7 +88,7 @@
   <script>
     document.querySelectorAll('a[data-path]').forEach(a => {
       a.addEventListener('click', e => {
-        const target = a.getAttribute('href');
+        const target = a.getAttribute('data-path');
 
         // --- 핵심 수정 로직 ---
         // 1. 현재 페이지가 iframe 안에서 실행되었고,


### PR DESCRIPTION
## Summary
- implement `loadPage.js` exporting `window.loadPage`
- integrate new module in main and preview index pages
- update nav click handler to pass `data-path`

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_686774092f0883299e2de6d8fcf69f41