### PR TITLE
Use dataset.path in nav handlers

### DIFF
--- a/nav.html
+++ b/nav.html
@@ -88,7 +88,7 @@
   <script>
     document.querySelectorAll('a[data-path]').forEach(a => {
       a.addEventListener('click', e => {
-        const target = a.getAttribute('data-path');
+        const target = a.dataset.path;
 
         // --- 핵심 수정 로직 ---
         // 1. 현재 페이지가 iframe 안에서 실행되었고,

--- a/preview/nav.html
+++ b/preview/nav.html
@@ -88,7 +88,7 @@
   <script>
     document.querySelectorAll('a[data-path]').forEach(a => {
       a.addEventListener('click', e => {
-        const target = a.getAttribute('data-path');
+        const target = a.dataset.path;
 
         // --- 핵심 수정 로직 ---
         // 1. 현재 페이지가 iframe 안에서 실행되었고,


### PR DESCRIPTION
## Summary
- use `a.dataset.path` in nav HTML click handlers
- keep `data-path` unchanged when loading nav but update `href` for direct navigation

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_68677774447483299f1f682ff0047cf1