### PR TITLE
Remove nav iframe placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,7 @@ LLM_GUIDE_END --><!-- ───────────────────�
 </head>
 <body class="animate-fadeIn text-base sm:text-lg lg:text-xl">
     <div class="frame-container p-4 sm:p-6">
-        <!-- <iframe id="nav-frame" class="h-[70px] md:h-[80px] lg:h-[90px]" loading="lazy"></iframe> -->
-        <div id="nav"></div> 
+        <div id="nav"></div>
         <iframe id="content-frame" name="content-display-area" loading="lazy"></iframe>
     </div>
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -17,7 +17,7 @@ assert(html.includes('▲') && html.includes('▼'), 'Arrow icons missing');
 const indexHtml = fs.readFileSync('index.html', 'utf8');
 assert(indexHtml.includes('<title>100x FenoK</title>'), 'Index title missing');
 assert(indexHtml.includes('meta name="description"'), 'Index meta description missing');
-assert(indexHtml.includes('<iframe id="nav-frame"'), 'Nav frame missing');
+assert(indexHtml.includes('<div id="nav">'), 'Nav container missing');
 assert(indexHtml.includes('<iframe id="content-frame"'), 'Content frame missing');
 
 // IB calculator page tests


### PR DESCRIPTION
## Summary
- drop commented `nav-frame` element from `index.html`
- update tests to look for `<div id="nav">`

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_68677ffd337c83298308911bd22ed8e7