### PR TITLE
Refactor base href detection

### DIFF
--- a/100x/daily-wrap/100x-daily-wrap-template.html
+++ b/100x/daily-wrap/100x-daily-wrap-template.html
@@ -9,33 +9,7 @@
     4. 각 섹션의 구조와 CSS 클래스는 디자인 일관성을 위해 수정하지 않는 것을 권장합니다.
     5. 자바스크립트의 `sectorData` 배열에 해당 날짜의 섹터별 데이터를 입력하면 히트맵이 자동으로 생성됩니다.
 --><html lang="ko"><head>
-	<script>
-	// 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-	(() => {
-		// 1. 현재 주소가 로컬 환경인지 확인
-		const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-		
-		// 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-		const isPreview = window.location.pathname.includes('/preview/');
-
-		let baseHref;
-
-		// 3. 환경에 따라 올바른 기본 경로를 설정
-		if (isLocal) {
-		baseHref = '/'; // 로컬 환경일 경우
-		} else if (isPreview) {
-		baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-		} else {
-		baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-		}
-        window.baseHref = baseHref;
-		
-		// 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-		if (!document.querySelector('base')) {
-		document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-		}
-	})();
-	</script>
+	<script type="module" src="../../initBaseHref.js"></script>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">

--- a/100x/daily-wrap/2025-06-21_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-21_100x-daily-wrap.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/100x/daily-wrap/2025-06-24_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-24_100x-daily-wrap.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/100x/daily-wrap/2025-06-25_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-25_100x-daily-wrap.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
@@ -29,33 +29,7 @@
 
     * **유연성 원칙:** 소스 데이터의 목차나 구조가 변경될 수 있음을 인지하고, 여기에 얽매이지 않습니다. 핵심은 '내용을 깊이 분석'하여 위 가이드라인에 맞춰 '최적의 형태'로 재구성하는 것입니다. 구조가 바뀌더라도 놀라지 말고, 유연하게 대처하여 일관된 품질을 유지하는 것이 중요합니다.
 --><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">

--- a/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
@@ -54,33 +54,7 @@
             -   **차이점 분류:** 발견된 차이점을 '의도된 변경', '정보 누락', '세부 정보 누락', '디자인 개선 필요' 등으로 명확히 분류합니다.
             -   **컨텍스트 기반의 해결책 제시:** 단순히 "A가 빠졌음"이라고 보고하는 것을 넘어, "A는 B라는 맥락에서 중요하므로 C 위치에 D 형식으로 추가해야 함"과 같이 구체적이고 실행 가능한 해결책을 제시합니다.
 --><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
@@ -33,33 +33,7 @@
         -   **정보 카드(Information Cards):** 경제 캘린더나 실적 발표처럼 목록형 정보는 단순 테이블 대신 개별 카드 형태로 표현하여 정보를 명확히 구분합니다. 특히 중요한 항목(ex: 핵심 PCE)은 `bg-yellow-100`과 같은 강조 색상을 사용하여 시각적 중요도를 높입니다.
         -   **분석/관점 블록(Viewpoint Blocks):** 필진의 핵심 분석을 담는 'Viewpoint' 또는 '관점' 단락은 `border-l-4`, `bg-gray-50` 등을 사용하여 시각적으로 구분되는 컴포넌트로 만듭니다. 문단 내 핵심 키워드를 `<b>` 태그로 강조하여 가독성을 높입니다.
 --><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">

--- a/100x/daily-wrap/2025-07-01_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-07-01_100x-daily-wrap.html
@@ -33,33 +33,7 @@
         -   **정보 카드(Information Cards):** 경제 캘린더나 실적 발표처럼 목록형 정보는 단순 테이블 대신 개별 카드 형태로 표현하여 정보를 명확히 구분합니다. 특히 중요한 항목(ex: 핵심 PCE)은 `bg-yellow-100`과 같은 강조 색상을 사용하여 시각적 중요도를 높입니다.
         -   **분석/관점 블록(Viewpoint Blocks):** 필진의 핵심 분석을 담는 'Viewpoint' 또는 '관점' 단락은 `border-l-4`, `bg-gray-50` 등을 사용하여 시각적으로 구분되는 컴포넌트로 만듭니다. 문단 내 핵심 키워드를 `<b>` 태그로 강조하여 가독성을 높입니다.
 --><html lang="ko"><head>
-	<script>
-	// 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-	(() => {
-		// 1. 현재 주소가 로컬 환경인지 확인
-		const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-		
-		// 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-		const isPreview = window.location.pathname.includes('/preview/');
-
-		let baseHref;
-
-		// 3. 환경에 따라 올바른 기본 경로를 설정
-		if (isLocal) {
-		baseHref = '/'; // 로컬 환경일 경우
-		} else if (isPreview) {
-		baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-		} else {
-		baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-		}
-        window.baseHref = baseHref;
-		
-		// 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-		if (!document.querySelector('base')) {
-		document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-		}
-	})();
-	</script>
+	<script type="module" src="../../initBaseHref.js"></script>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">

--- a/100x/daily-wrap/2025-07-02_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-07-02_100x-daily-wrap.html
@@ -12,20 +12,7 @@
     5. 키워드 강조 규칙(b 태그 및 색상 클래스)을 모든 섹션에 일관되게 적용.
     6. 데이터 누락 방지를 위한 자체 검증 절차(항목 수 계산) 완료.
 --><html lang="ko"><head>
-	<script>
-	// 로컬(127.0.0.1 또는 localhost)과 GitHub Pages 환경을 자동으로 감지하는 스크립트
-	(() => {
-		// 현재 주소가 로컬 환경인지 정규식으로 확인
-		const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-		// 환경에 따라 올바른 기본 경로를 설정
-                const baseHref = isLocal ? '/' : '/100xFenok/';
-                window.baseHref = baseHref;
-                // <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가 (중복 방지)
-                if (!document.querySelector('base')) {
-                document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-                }
-	})();
-	</script>
+	<script type="module" src="../../initBaseHref.js"></script>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">

--- a/100x/index.html
+++ b/100x/index.html
@@ -35,33 +35,7 @@
 
     * **유연성 원칙:** 소스 데이터의 목차나 구조가 변경될 수 있음을 인지하고, 여기에 얽매이지 않습니다. 핵심은 '내용을 깊이 분석'하여 위 가이드라인에 맞춰 '최적의 형태'로 재구성하는 것입니다. 구조가 바뀌더라도 놀라지 말고, 유연하게 대처하여 일관된 품질을 유지하는 것이 중요합니다.
 --><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/404.html
+++ b/404.html
@@ -1,33 +1,7 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-      // 1. 현재 주소가 로컬 환경인지 확인
-      const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-      
-      // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-      const isPreview = window.location.pathname.includes('/preview/');
-
-      let baseHref;
-
-      // 3. 환경에 따라 올바른 기본 경로를 설정
-      if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-      } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-      } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-      }
-        window.baseHref = baseHref;
-      
-      // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-      if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-      }
-    })();
-  </script>
+  <script type="module" src="initBaseHref.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Noto+Sans+KR:wght@500;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/ib/ib-total-guide-calculator.html
+++ b/ib/ib-total-guide-calculator.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/index.html
+++ b/index.html
@@ -50,33 +50,7 @@ LLM_GUIDE_END --><!-- ───────────────────�
 4) 페이지/리소스 수정 시 siteVersion 반드시 증가 (?v=버전)
 5) 브라우저 캐시가 남을 땐 CTRL-F5로 강제 새로고침
 ────────────────────────────────────────────────── --><html lang="ko"><head>
-    <script>
-      // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-      (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-          baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-          baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-          baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-          document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-      })();
-    </script>
+    <script type="module" src="initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/initBaseHref.js
+++ b/initBaseHref.js
@@ -1,0 +1,10 @@
+(() => {
+  const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
+  const isPreview = window.location.pathname.includes('/preview/');
+  const baseHref = isLocal ? '/' : isPreview ? '/100xFenok/preview/' : '/100xFenok/';
+  window.baseHref = baseHref;
+  if (!document.querySelector('base')) {
+    document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
+  }
+})();
+

--- a/main.html
+++ b/main.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-  <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-      // 1. 현재 주소가 로컬 환경인지 확인
-      const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-      
-      // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-      const isPreview = window.location.pathname.includes('/preview/');
-
-      let baseHref;
-
-      // 3. 환경에 따라 올바른 기본 경로를 설정
-      if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-      } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-      } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-      }
-        window.baseHref = baseHref;
-      
-      // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-      if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-      }
-    })();
-  </script>
+  <script type="module" src="initBaseHref.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/nav.html
+++ b/nav.html
@@ -1,33 +1,7 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-      // 1. 현재 주소가 로컬 환경인지 확인
-      const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-      
-      // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-      const isPreview = window.location.pathname.includes('/preview/');
-
-      let baseHref;
-
-      // 3. 환경에 따라 올바른 기본 경로를 설정
-      if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-      } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-      } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-      }
-        window.baseHref = baseHref;
-      
-      // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-      if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-      }
-    })();
-  </script>
+  <script type="module" src="initBaseHref.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Noto+Sans+KR:wght@500;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/posts/2025-06-22_playbook.html
+++ b/posts/2025-06-22_playbook.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
+++ b/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/posts/2025-06-30_Alpha_Pick_RMD/index.html
+++ b/posts/2025-06-30_Alpha_Pick_RMD/index.html
@@ -1,33 +1,7 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ResMed (RMD) Alpha Pick | 100x FenoK 투자 분석</title>

--- a/posts/index.html
+++ b/posts/index.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700;900&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/100x/index.html
+++ b/preview/100x/index.html
@@ -35,33 +35,7 @@
 
     * **유연성 원칙:** 소스 데이터의 목차나 구조가 변경될 수 있음을 인지하고, 여기에 얽매이지 않습니다. 핵심은 '내용을 깊이 분석'하여 위 가이드라인에 맞춰 '최적의 형태'로 재구성하는 것입니다. 구조가 바뀌더라도 놀라지 말고, 유연하게 대처하여 일관된 품질을 유지하는 것이 중요합니다.
 --><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/404.html
+++ b/preview/404.html
@@ -1,33 +1,7 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-      // 1. 현재 주소가 로컬 환경인지 확인
-      const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-      
-      // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-      const isPreview = window.location.pathname.includes('/preview/');
-
-      let baseHref;
-
-      // 3. 환경에 따라 올바른 기본 경로를 설정
-      if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-      } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-      } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-      }
-        window.baseHref = baseHref;
-      
-      // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-      if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-      }
-    })();
-  </script>
+  <script type="module" src="../initBaseHref.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Noto+Sans+KR:wght@500;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/ib/ib-total-guide-calculator.html
+++ b/preview/ib/ib-total-guide-calculator.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/index.html
+++ b/preview/index.html
@@ -50,33 +50,7 @@ LLM_GUIDE_END --><!-- ───────────────────�
 4) 페이지/리소스 수정 시 siteVersion 반드시 증가 (?v=버전)
 5) 브라우저 캐시가 남을 땐 CTRL-F5로 강제 새로고침
 ────────────────────────────────────────────────── --><html lang="ko"><head>
-    <script>
-      // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-      (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-          baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-          baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-          baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-          document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-      })();
-    </script>
+    <script type="module" src="../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/main.html
+++ b/preview/main.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-  <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-      // 1. 현재 주소가 로컬 환경인지 확인
-      const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-      
-      // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-      const isPreview = window.location.pathname.includes('/preview/');
-
-      let baseHref;
-
-      // 3. 환경에 따라 올바른 기본 경로를 설정
-      if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-      } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-      } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-      }
-        window.baseHref = baseHref;
-      
-      // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-      if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-      }
-    })();
-  </script>
+  <script type="module" src="../initBaseHref.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/nav.html
+++ b/preview/nav.html
@@ -1,33 +1,7 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-      // 1. 현재 주소가 로컬 환경인지 확인
-      const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-      
-      // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-      const isPreview = window.location.pathname.includes('/preview/');
-
-      let baseHref;
-
-      // 3. 환경에 따라 올바른 기본 경로를 설정
-      if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-      } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-      } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-      }
-        window.baseHref = baseHref;
-      
-      // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-      if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-      }
-    })();
-  </script>
+  <script type="module" src="../initBaseHref.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Noto+Sans+KR:wght@500;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/posts/2025-06-22_playbook.html
+++ b/preview/posts/2025-06-22_playbook.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
+++ b/preview/posts/2025-06-23_stablecoin-revolution-complete-masterplan.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/posts/2025-06-30_Alpha_Pick_RMD/index.html
+++ b/preview/posts/2025-06-30_Alpha_Pick_RMD/index.html
@@ -1,33 +1,7 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../../initBaseHref.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ResMed (RMD) Alpha Pick | 100x FenoK 투자 분석</title>

--- a/preview/posts/index.html
+++ b/preview/posts/index.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700;900&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/tools/asset/multichart.html
+++ b/preview/tools/asset/multichart.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-  <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-      // 1. 현재 주소가 로컬 환경인지 확인
-      const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-      
-      // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-      const isPreview = window.location.pathname.includes('/preview/');
-
-      let baseHref;
-
-      // 3. 환경에 따라 올바른 기본 경로를 설정
-      if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-      } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-      } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-      }
-        window.baseHref = baseHref;
-      
-      // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-      if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-      }
-    })();
-  </script>
+  <script type="module" src="../../../initBaseHref.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/vr/index.html
+++ b/preview/vr/index.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/vr/vr-complete-system.html
+++ b/preview/vr/vr-complete-system.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/preview/vr/vr-total-guide-calculator.html
+++ b/preview/vr/vr-total-guide-calculator.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/tools/asset/multichart.html
+++ b/tools/asset/multichart.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-  <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-      // 1. 현재 주소가 로컬 환경인지 확인
-      const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-      
-      // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-      const isPreview = window.location.pathname.includes('/preview/');
-
-      let baseHref;
-
-      // 3. 환경에 따라 올바른 기본 경로를 설정
-      if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-      } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-      } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-      }
-        window.baseHref = baseHref;
-      
-      // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-      if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-      }
-    })();
-  </script>
+  <script type="module" src="../../initBaseHref.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/vr/index.html
+++ b/vr/index.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/vr/vr-complete-system.html
+++ b/vr/vr-complete-system.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/vr/vr-total-guide-calculator.html
+++ b/vr/vr-total-guide-calculator.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html><html lang="ko"><head>
-    <script>
-    // 로컬, GitHub 메인, GitHub Preview 환경을 모두 자동으로 감지하는 스크립트
-    (() => {
-        // 1. 현재 주소가 로컬 환경인지 확인
-        const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
-        
-        // 2. 현재 경로에 '/preview/'가 포함되어 있는지 확인
-        const isPreview = window.location.pathname.includes('/preview/');
-
-        let baseHref;
-
-        // 3. 환경에 따라 올바른 기본 경로를 설정
-        if (isLocal) {
-        baseHref = '/'; // 로컬 환경일 경우
-        } else if (isPreview) {
-        baseHref = '/100xFenok/preview/'; // GitHub의 Preview 폴더일 경우
-        } else {
-        baseHref = '/100xFenok/'; // GitHub의 메인 폴더일 경우
-        }
-        window.baseHref = baseHref;
-        
-        // 4. <base> 태그가 이미 존재하는지 확인 후, 없을 때만 추가
-        if (!document.querySelector('base')) {
-        document.head.insertAdjacentHTML('afterbegin', `<base href="${baseHref}">`);
-        }
-    })();
-    </script>
+    <script type="module" src="../initBaseHref.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&amp;family=Noto+Sans+KR:wght@500;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
## Summary
- DRY up pages by extracting base href logic into a reusable `initBaseHref.js`
- reference `initBaseHref.js` from all HTML pages with relative paths

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_686782cb46748329a20a6a39d14c15e0