### PR TITLE
Improve local detection in base href initializer

### DIFF
--- a/initBaseHref.js
+++ b/initBaseHref.js
@@ -1,5 +1,9 @@
 (() => {
-  const isLocal = /^(127\.0\.0\.1|localhost)$/.test(location.hostname);
+  // Treat local hosts, LAN addresses like 192.168.* and file:// protocol as local
+  const isLocalHost = /^(127\.0\.0\.1|localhost|192\.168\.\d+\.\d+)$/.test(location.hostname);
+  const isLocalProtocol = location.protocol === 'file:';
+  const isLocal = isLocalHost || isLocalProtocol;
+
   const isPreview = window.location.pathname.includes('/preview/');
   const baseHref = isLocal ? '/' : isPreview ? '/100xFenok/preview/' : '/100xFenok/';
   window.baseHref = baseHref;


### PR DESCRIPTION
## Summary
- enhance `initBaseHref.js` so local addresses such as `file:` protocol or `192.168.*` hostnames are treated as local

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6867941f77f88329ab956a5bf885f3c1