### PR TITLE
Fix nav on 404 + Alpha Pick pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -19,11 +19,18 @@
   </style>
 </head>
 <body class="h-screen flex items-center justify-center bg-slate-50 text-slate-800">
+  <div id="nav"></div>
   <div class="text-center p-6">
     <h1 class="text-5xl font-bold mb-4">404</h1>
     <p class="mb-6 text-lg">죄송합니다. 요청하신 페이지를 찾을 수 없습니다.</p>
     <a href="./index.html" class="text-blue-600 hover:underline">메인 페이지로 돌아가기</a>
   </div>
-  <script type="module" src="./version.js"></script>
+  <script type="module">
+    const { siteVersion } = await import(`${window.baseHref}version.js`);
+    const { loadNav } = await import(`${window.baseHref}loadNav.js`);
+    if (window.top === window.self) {
+        await loadNav(siteVersion);
+    }
+  </script>
 </body>
 </html>

--- a/posts/2025-06-30_Alpha_Pick_RMD/index.html
+++ b/posts/2025-06-30_Alpha_Pick_RMD/index.html
@@ -34,7 +34,8 @@
 	<script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
-	<!-- contents navigator -->
+  <div id="nav"></div>
+        <!-- contents navigator -->
     <!-- <div class="group fixed top-1/4 -translate-y-1/2 right-0 z-50">
       <nav class="transform translate-x-[calc(100%-20px)] group-hover:translate-x-0 transition-transform duration-500">
         <div class="bg-slate-900/80 backdrop-blur-lg rounded-l-2xl shadow-lg p-4 space-y-2 border border-slate-700 w-48">
@@ -1225,8 +1226,15 @@
 	</footer>
 
     <!-- Scripts -->
-	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
-	<script src="app.js"></script>
+    <script src="app.js"></script>
+    <script type="module">
+      const { siteVersion } = await import(`${window.baseHref}version.js`);
+      const { loadNav } = await import(`${window.baseHref}loadNav.js`);
+      if (window.top === window.self) {
+          await loadNav(siteVersion);
+      }
+    </script>
 </body>
 </html>

--- a/preview/404.html
+++ b/preview/404.html
@@ -19,11 +19,18 @@
   </style>
 </head>
 <body class="h-screen flex items-center justify-center bg-slate-50 text-slate-800">
+  <div id="nav"></div>
   <div class="text-center p-6">
     <h1 class="text-5xl font-bold mb-4">404</h1>
     <p class="mb-6 text-lg">죄송합니다. 요청하신 페이지를 찾을 수 없습니다.</p>
     <a href="./index.html" class="text-blue-600 hover:underline">메인 페이지로 돌아가기</a>
   </div>
-  <script type="module" src="./version.js"></script>
+  <script type="module">
+    const { siteVersion } = await import(`${window.baseHref}version.js`);
+    const { loadNav } = await import(`${window.baseHref}loadNav.js`);
+    if (window.top === window.self) {
+        await loadNav(siteVersion);
+    }
+  </script>
 </body>
 </html>

--- a/preview/posts/2025-06-30_Alpha_Pick_RMD/index.html
+++ b/preview/posts/2025-06-30_Alpha_Pick_RMD/index.html
@@ -34,7 +34,8 @@
 	<script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
-	<!-- contents navigator -->
+  <div id="nav"></div>
+        <!-- contents navigator -->
     <!-- <div class="group fixed top-1/4 -translate-y-1/2 right-0 z-50">
       <nav class="transform translate-x-[calc(100%-20px)] group-hover:translate-x-0 transition-transform duration-500">
         <div class="bg-slate-900/80 backdrop-blur-lg rounded-l-2xl shadow-lg p-4 space-y-2 border border-slate-700 w-48">
@@ -1225,8 +1226,15 @@
 	</footer>
 
     <!-- Scripts -->
-	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
-	<script src="app.js"></script>
+    <script src="app.js"></script>
+    <script type="module">
+      const { siteVersion } = await import(`${window.baseHref}version.js`);
+      const { loadNav } = await import(`${window.baseHref}loadNav.js`);
+      if (window.top === window.self) {
+          await loadNav(siteVersion);
+      }
+    </script>
 </body>
 </html>

--- a/preview/version.js
+++ b/preview/version.js
@@ -1,1 +1,1 @@
-export const siteVersion = '20250703T0106';
+export const siteVersion = '20250703T0107';

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-export const siteVersion = '20250703T0106';
+export const siteVersion = '20250703T0107';


### PR DESCRIPTION
## Summary
- add nav insertion to 404 page
- sync preview 404 page
- integrate SPA nav on Alpha Pick article
- bump siteVersion to bust cache

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6868764f6e9c8329b4e9cfce53fc6972