### PR TITLE
Update docs on nav shell

### DIFF
--- a/100x/100x-main.html
+++ b/100x/100x-main.html
@@ -31,7 +31,7 @@ if (window.top === window.self) {
     3.  **구조와 시맨틱 (Structure & Semantics):**
         -   페이지를 '최신 리포트 하이라이트', '리포트 아카이브' 두 부분으로 명확히 나눕니다. Hero 섹션은 콘텐츠 집중을 위해 의도적으로 제거했습니다.
         -   정보의 위계가 중요합니다. 사용자의 관심이 가장 높은 최신 리포트는 상단에 자세히 배치하고, 오래된 정보는 하단에 간결하게 목록화하여 정보의 중요도에 따라 접근성을 차등적으로 설계합니다.
-        -   FenoK(또는 El Fenomeno Kim)의 브랜딩이 푸터 등에 일관되게 적용되어야 합니다.
+        -   FenoK(또는 El Fenomeno Kim)의 브랜딩은 index.html/404.html 푸터와 일관되도록 유지해야 합니다.
 
     4.  **시각화 일관성 (Consistent Visualization):**
         -   **디자인 테마:** `bg-slate-50`을 기본 배경으로 사용하고, 카드에는 `bg-white`와 `card-shadow`를 적용하여 깨끗하고 입체적인 느낌을 줍니다.

--- a/100x/daily-wrap/100x-daily-wrap-template.html
+++ b/100x/daily-wrap/100x-daily-wrap-template.html
@@ -1076,16 +1076,7 @@ if (window.top === window.self) {
                 });
             }
 
-            // 네비게이션 로딩 스크립트 (수정 불필요)
-            const navScript = document.createElement('script');
-            navScript.type = 'module';
-            navScript.innerHTML = `
-                이 부분은 상위 폴더의 네비게이션 파일을 로드하는 스크립트입니다.
-                로컬 환경이나 다른 서버 구조에서는 경로 수정이 필요할 수 있습니다.
-                if (window.top === window.self) {
-                }
-            `;
-            document.body.appendChild(navScript);
+            // SPA shell(index.html) provides navigation and footer
         });
     </script>
 

--- a/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-26_100x-daily-wrap.html
@@ -25,7 +25,7 @@ if (window.top === window.self) {
     3.  **구조와 시맨틱 (Structure & Semantics):**
         -   콘텐츠의 논리적 흐름에 따라 `<section>`으로 명확하게 구획을 나눕니다. 각 섹션의 제목은 `<h2>` 태그를 사용합니다.
         -   정보의 위계가 중요합니다. 가장 중요한 '요약'과 '핵심 지표'를 최상단에 배치하고, 상세 데이터와 부록은 그 아래에 순차적으로 구성합니다.
-        -   FenoK(또는 El Fenomeno Kim)의 브랜딩이 푸터 등에 일관되게 적용되어야 합니다.
+        -   FenoK(또는 El Fenomeno Kim)의 브랜딩은 index.html/404.html 푸터와 일관되도록 유지해야 합니다.
 
     4.  **시각화 일관성 (Consistent Visualization):**
         -   **아이콘:** Font Awesome 아이콘을 사용하여 섹션의 주제를 암시하고 텍스트에 생동감을 더합니다.
@@ -63,7 +63,7 @@ if (window.top === window.self) {
     </style>
 </head>
 <body class="bg-gray-50 text-gray-900 min-h-screen">
-    <!-- 네비게이션: FenoK의 다른 플랫폼으로 연결되는 일관된 탐색 경험 제공 -->
+    <!-- SPA shell(index.html) handles navigation -->
 
 
 

--- a/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-27_100x-daily-wrap.html
@@ -30,7 +30,7 @@ if (window.top === window.self) {
     3.  **구조와 시맨틱 (Structure & Semantics):**
         -   콘텐츠의 논리적 흐름에 따라 `<section>`으로 명확하게 구획을 나눕니다. 각 섹션의 제목은 `<h2>` 태그를 사용합니다.
         -   정보의 위계가 중요합니다. 가장 중요한 '요약'과 '핵심 지표'를 최상단에 배치하고, 상세 데이터와 부록은 그 아래에 순차적으로 구성합니다.
-        -   FenoK(또는 El Fenomeno Kim)의 브랜딩이 푸터 등에 일관되게 적용되어야 합니다.
+        -   FenoK(또는 El Fenomeno Kim)의 브랜딩은 index.html/404.html 푸터와 일관되도록 유지해야 합니다.
 
     4.  **시각화 일관성 및 창의성 (Consistent & Creative Visualization):**
         -   **아이콘의 체계적 활용(Systematic Use of Icons):** 아이콘은 단순히 장식용이 아닙니다. 긍정(초록), 부정(빨강), 중립/정책(파랑/보라) 등 내용의 성격에 맞는 색상을 체계적으로 사용하여 정보를 직관적으로 전달하는 역할을 합니다.

--- a/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-06-28_100x-daily-wrap.html
@@ -30,7 +30,7 @@ if (window.top === window.self) {
     3.  **구조와 시맨틱 (Structure & Semantics):**
         -   콘텐츠의 논리적 흐름에 따라 `<section>`으로 명확하게 구획을 나눕니다. 각 섹션의 제목은 `<h2>` 태그를 사용합니다.
         -   정보의 위계가 중요합니다. 가장 중요한 '요약'과 '핵심 지표'를 최상단에 배치하고, 상세 데이터와 부록은 그 아래에 순차적으로 구성합니다.
-        -   FenoK(또는 El Fenomeno Kim)의 브랜딩이 푸터 등에 일관되게 적용되어야 합니다.
+        -   FenoK(또는 El Fenomeno Kim)의 브랜딩은 index.html/404.html 푸터와 일관되도록 유지해야 합니다.
 
     4.  **시각화 일관성 및 창의성 (Consistent & Creative Visualization):**
         -   **아이콘의 체계적 활용(Systematic Use of Icons):** 아이콘은 단순히 장식용이 아닙니다. 긍정(초록), 부정(빨강), 중립/정책(파랑/보라) 등 내용의 성격에 맞는 색상을 체계적으로 사용하여 정보를 직관적으로 전달하는 역할을 합니다.

--- a/100x/daily-wrap/2025-07-01_100x-daily-wrap.html
+++ b/100x/daily-wrap/2025-07-01_100x-daily-wrap.html
@@ -30,7 +30,7 @@ if (window.top === window.self) {
     3.  **구조와 시맨틱 (Structure & Semantics):**
         -   콘텐츠의 논리적 흐름에 따라 `<section>`으로 명확하게 구획을 나눕니다. 각 섹션의 제목은 `<h2>` 태그를 사용합니다.
         -   정보의 위계가 중요합니다. 가장 중요한 '요약'과 '핵심 지표'를 최상단에 배치하고, 상세 데이터와 부록은 그 아래에 순차적으로 구성합니다.
-        -   FenoK(또는 El Fenomeno Kim)의 브랜딩이 푸터 등에 일관되게 적용되어야 합니다.
+        -   FenoK(또는 El Fenomeno Kim)의 브랜딩은 index.html/404.html 푸터와 일관되도록 유지해야 합니다.
 
     4.  **시각화 일관성 및 창의성 (Consistent & Creative Visualization):**
         -   **아이콘의 체계적 활용(Systematic Use of Icons):** 아이콘은 단순히 장식용이 아닙니다. 긍정(초록), 부정(빨강), 중립/정책(파랑/보라) 등 내용의 성격에 맞는 색상을 체계적으로 사용하여 정보를 직관적으로 전달하는 역할을 합니다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,32 +15,22 @@ This document outlines structural, behavioral, and coding conventions for Codex 
 
 ## 🧭 Navigation Structure
 
-- Do **NOT** hardcode nav into each HTML file.
-- All pages must dynamically inject `<div id="nav"></div>` and run `loadNav(siteVersion)` from `loadNav.js`.
+- Navigation and footer markup exist **only** in `index.html` and `404.html`, which act as the SPA shell.
+- Content pages must **not** embed navigation or footer sections themselves.
 
-### Required setup for each HTML:
+### Required setup for each content HTML
 
 **In `<head>`**
 ```html
-<script type="module" src="./initBaseHref.js"></script>
+<script type="module" src="../initBaseHref.js"></script>
 ```
-(Use `../` or `../../` based on file depth)
+(Adjust the `../` depth based on the file location.)
 
-**At top of `<body>`**
+**At start of `<body>`**
 ```html
 <div id="nav"></div>
 ```
-
-**At bottom of `<body>`**
-```html
-<script type="module">
-  const { siteVersion } = await import(`${window.baseHref}version.js`);
-  const { loadNav } = await import(`${window.baseHref}loadNav.js`);
-  if (window.top === window.self) {
-      await loadNav(siteVersion);
-  }
-</script>
-```
+This placeholder keeps the layout consistent even though navigation is not injected here.
 
 ---
 
@@ -65,18 +55,17 @@ This document outlines structural, behavioral, and coding conventions for Codex 
 
 ## 📄 File Editing Rules
 
-- Every file must include:
-  - initBaseHref
-  - version.js
-  - loadNav.js
-  - div#nav container
+- Content pages must include:
+  - `<script type="module" src="../initBaseHref.js"></script>` with the correct relative path
+  - `<div id="nav"></div>` as the first element in `<body>`
+  - No embedded navigation or footer markup
 
 ---
 
 ## 🆕 When Adding a New Page
 
 1. Add content under correct folder (`/posts/`, `/100x/daily-wrap/`, etc.)
-2. Include nav injection logic as above
+2. Include the `initBaseHref.js` script and `<div id="nav"></div>` placeholder as shown above
 3. Update `/posts/index.html` or `/100x/index.html` **only when prompted**
 4. Bump `siteVersion` in `version.js` **only if instructed**
 5. Run `node tests/run-tests.js` after major HTML changes
@@ -95,7 +84,7 @@ node tests/run-tests.js
 
 ## 📄 Commit/PR Notes
 
-- Always summarize each major change (e.g., "Applied nav injection to Alpha Pick post")
+- Always summarize each major change (e.g., "Updated VR calculator tables")
 - List all edited files
 - If version bumped, include version string (e.g., 20250703T0107)
 

--- a/FOLDER_GUIDE.md
+++ b/FOLDER_GUIDE.md
@@ -10,7 +10,7 @@
 | ------------------------------- | ------------------------------------------------------- |
 | `index.html`                    | SPA 진입점 – `iframe#content-frame`으로 전체 구조 형성 |
 | `main.html`                     | 홈 콘텐츠 – What's New 카드/버튼 등 표시                           |
-| `loadPage.js`, `loadNav.js`     | SPA 방식 페이지 전환 및 동적 nav 삽입 스크립트                          |
+| `loadPage.js`, `loadNav.js`     | SPA 페이지 로딩 로직, nav은 index/404에서만 사용 |
 | `initBaseHref.js`               | GitHub Pages/preview/로컬 경로를 자동 판단하여 `<base href>` 설정    |
 | `version.js`                    | `siteVersion` 값을 통해 캐시 무효화를 제어함                         |
 | `AGENTS.md`                     | 전체 시스템 유지보수용 Codex 작업 기준 규칙 문서                          |
@@ -92,7 +92,7 @@
 
 ## 📌 폴더 구조 운영 원칙 요약
 
-1. 모든 index.html은 반드시 `<div id="nav"></div>` 및 `initBaseHref.js` 포함
+1. 모든 콘텐츠 페이지는 `<script type="module" src="../initBaseHref.js"></script>`를 포함하고 `<body>` 시작부에 `<div id="nav"></div>`를 배치한다 (nav와 footer는 index.html/404.html에만 존재)
 2. `_agent-prompts/` 폴더는 폴더별 기능 단위로만 존재해야 함
 3. `version.js`는 HTML/JS/CSS 수정 시 반드시 갱신
 4. preview 디렉토리는 항상 루트와 경로만 다르게 복사되어야 함

--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ index.html      SPA entry containing the iframe loader
 version.js      Cache busting constant
 ```
 
+Only `index.html` and `404.html` include the site's navigation and footer. Every
+other page should remain content-only. Place
+
+```html
+<script type="module" src="../initBaseHref.js"></script>
+```
+
+in the `<head>` (adjust `../` depth as needed) and begin the `<body>` with
+
+```html
+<div id="nav"></div>
+```
+
+as a placeholder for SPA compatibility.
+
 ## Usage
 
 After starting a local server, open `index.html` in your browser to launch the application. All internal navigation uses the `?path=` query to load content pages. `404.html` performs a universal redirect so any deep link or broken URL is absorbed back into `index.html?path=...`.


### PR DESCRIPTION
## Summary
- clarify that nav and footer live only in the SPA shell
- document placeholder `div#nav` and `initBaseHref` usage on content pages
- clean up comments about nav injection

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6868d5d0054c83299b94059627d29dac