### PR TITLE
Fix broken images in hilton_revised_jules.html

### DIFF
--- a/miyako/hilton_revised_jules.html
+++ b/miyako/hilton_revised_jules.html
@@ -638,7 +638,7 @@
                   <p class="text-sm text-ocean-600">올데이 다이닝</p>
                 </div>
               </div>
-              <img alt="아주르 레스토랑 내부" class="w-full h-48 object-cover rounded-lg mb-4" src="https://www.hilton.com/images/JP/MIYHIHI/gallery/miyhihi_all_day_dining_1_1200x600.jpg"/>
+              <img alt="아주르 레스토랑 내부" class="w-full h-48 object-cover rounded-lg mb-4" src="https://kimi-web-img.moonshot.cn/img/media-cdn.tripadvisor.com/fe993cc8f9d4938620d73a437e9a4508ca0bbf38.jpg"/>
               <p class="text-ocean-800 leading-relaxed mb-4">
                 호텔의 메인 올데이 다이닝 레스토랑으로, 신선한 해산물 뷔페와 오키나와 특산품을 맛볼 수 있습니다. 조식, 중식, 석식 모두 제공됩니다.
               </p>
@@ -688,7 +688,7 @@
                     <p class="text-sm text-sand-700">로비 라운지</p>
                 </div>
               </div>
-               <img alt="로비 라운지 '사료' 내부" class="w-full h-48 object-cover rounded-lg mb-4" src="https://www.hilton.com/images/JP/MIYHIHI/gallery/miyhihi_lobby_lounge_2_1200x600.jpg"/>
+               <img alt="로비 라운지 '사료' 내부" class="w-full h-48 object-cover rounded-lg mb-4" src="https://www.japan-guide.com/g18/2096_01.jpg"/>
               <p class="text-ocean-800 leading-relaxed mb-4">
                 로비 라운지로, 전통 일본 차 문화를 현대적으로 재해석한 공간입니다. 다양한 차와 전통 과자, 가벼운 식사를 즐길 수 있습니다.
               </p>
@@ -713,7 +713,7 @@
                     <p class="text-sm text-coral-600">루프탑 바</p>
                 </div>
               </div>
-              <img alt="루프탑 바 '유나이'의 석양" class="w-full h-48 object-cover rounded-lg mb-4" src="https://www.hilton.com/images/JP/MIYHIHI/gallery/miyhihi_rooftop_bar_1_1200x600.jpg"/>
+              <img alt="루프탑 바 '유나이'의 석양" class="w-full h-48 object-cover rounded-lg mb-4" src="https://kimi-web-img.moonshot.cn/img/offloadmedia.feverup.com/707b106d7e1dca797406d1016ddd97d92be3ef12.jpg"/>
               <p class="text-ocean-800 leading-relaxed mb-4">
                 8층 루프탑 바로, 미야코지마의 석양과 오션뷰를 파노라마로 감상하며 오리지널 칵테일을 즐길 수 있는 특별한 공간입니다.
               </p>


### PR DESCRIPTION
Replaced three broken image URLs in the "Dining & Bar" section of the Miyako Hilton guide.

- Updated the 'Azure' and 'Yunai' image URLs to the correct sources as found in the original `hilton.html` file.
- Replaced the 'Saryo' image with a new, user-approved image representing "traditional Japanese tea culture", as the original file did not contain a source for it.

This resolves the issue of broken images not displaying on the page.