### PR TITLE
feat(miyakojima): create responsive main landing page

### DIFF
--- a/miyakojima/main.css
+++ b/miyakojima/main.css
@@ -1,0 +1,100 @@
+/* --- Google Fonts Import --- */
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&family=Poppins:wght@700&display=swap');
+
+/* --- General Styles --- */
+body {
+    font-family: 'Noto Sans KR', sans-serif;
+    margin: 0;
+    background-color: #f0f8ff; /* AliceBlue - a light, cheerful blue */
+    color: #333;
+    text-align: center;
+}
+
+/* --- Header --- */
+header {
+    padding: 2rem 1rem;
+    background-color: #ffffff;
+    border-bottom: 2px solid #e0e0e0;
+}
+
+h1 {
+    font-family: 'Poppins', sans-serif;
+    color: #0077b6; /* A nice, deep blue */
+    font-size: 2.5rem;
+    margin: 0;
+}
+
+/* --- Main Content & Card Container --- */
+main {
+    padding: 2rem 1rem;
+}
+
+.card-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+/* --- Card Styles --- */
+.card {
+    display: flex;
+    align-items: flex-end; /* Aligns content to the bottom */
+    justify-content: center;
+    min-height: 350px;
+    background-size: cover;
+    background-position: center;
+    border-radius: 15px;
+    text-decoration: none;
+    color: white;
+    overflow: hidden;
+    position: relative;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+    transform: translateY(-5px) scale(1.02);
+    box-shadow: 0 8px 16px rgba(0,0,0,0.2);
+}
+
+/* --- Card Background Images --- */
+/* Using placeholder images. These can be replaced easily. */
+.card:nth-of-type(1) {
+    background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.4)), url('https://picsum.photos/seed/resort/800/600');
+}
+
+.card:nth-of-type(2) {
+    background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.4)), url('https://picsum.photos/seed/beach/800/600');
+}
+
+/* --- Card Content --- */
+.card-content {
+    background-color: rgba(0, 0, 0, 0.3);
+    width: 100%;
+    padding: 1rem;
+    box-sizing: border-box; /* Ensures padding doesn't affect width */
+}
+
+.card h2 {
+    font-family: 'Poppins', sans-serif;
+    font-size: 1.8rem;
+    margin: 0;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.7);
+}
+
+/* --- Responsive Adjustments --- */
+@media (max-width: 600px) {
+    h1 {
+        font-size: 2rem;
+    }
+
+    .card {
+        min-height: 250px;
+    }
+
+    .card h2 {
+        font-size: 1.5rem;
+    }
+}

--- a/miyakojima/main.html
+++ b/miyakojima/main.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Miyakojima Trip Planner</title>
+    <link rel="stylesheet" href="main.css">
+</head>
+<body>
+
+    <header>
+        <h1>Our Miyakojima Adventure</h1>
+    </header>
+
+    <main>
+        <div class="card-container">
+
+            <a href="pages/hilton.html" class="card">
+                <div class="card-content">
+                    <h2>Hilton Resort</h2>
+                    <!-- 나중에 여기에 설명을 추가할 수 있습니다. <p>...</p> -->
+                </div>
+            </a>
+
+            <a href="pages/miyako.html" class="card">
+                <div class="card-content">
+                    <h2>Miyako Island</h2>
+                    <!-- 나중에 여기에 설명을 추가할 수 있습니다. <p>...</p> -->
+                </div>
+            </a>
+
+            <!--
+            새로운 페이지를 추가하려면 아래와 같은 형식으로 카드를 추가하세요.
+            <a href="pages/your-new-page.html" class="card">
+                <div class="card-content">
+                    <h2>New Page Title</h2>
+                </div>
+            </a>
+            -->
+
+        </div>
+    </main>
+
+</body>
+</html>


### PR DESCRIPTION
Creates a new main landing page for the Miyakojima trip planning section.

- Implements a responsive, card-based layout using CSS Grid that works on desktop and mobile devices.
- Adds links to the existing 'Hilton' and 'Miyako' pages.
- Establishes a 'bright, fun, and cheerful' visual theme with custom fonts and placeholder images.
- The HTML is commented to make it easy to add new page links in the future, fulfilling the user's requirement for scalability.