### PR TITLE
fix(miyakojima): Correct asset paths for GitHub Pages

### DIFF
--- a/miyakojima/miyakojima-web/js/app.js
+++ b/miyakojima/miyakojima-web/js/app.js
@@ -713,7 +713,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 // 서비스 워커 등록 (PWA)
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw.js')
+        navigator.serviceWorker.register('sw.js')
             .then(registration => {
                 Logger.info('Service Worker 등록 성공:', registration);
             })

--- a/miyakojima/miyakojima-web/js/config.js
+++ b/miyakojima/miyakojima-web/js/config.js
@@ -139,12 +139,6 @@ const CONFIG = {
         }
     },
     
-    // 디버그 설정
-    DEBUG: {
-        ENABLED: true,
-        LOG_LEVEL: 'info' // debug, info, warn, error
-    },
-
     // 캐싱 및 저장소 설정
     STORAGE: {
         PREFIX: 'miyakojima_',

--- a/miyakojima/miyakojima-web/sw.js
+++ b/miyakojima/miyakojima-web/sw.js
@@ -5,19 +5,18 @@ const DATA_CACHE = 'data-v1';
 
 // Files to cache immediately
 const STATIC_FILES = [
-    '/',
-    '/index.html',
-    '/css/main.css',
-    '/css/mobile.css',
-    '/js/app.js',
-    '/js/config.js',
-    '/js/utils.js',
-    '/js/api.js',
-    '/js/budget.js',
-    '/js/location.js',
-    '/js/poi.js',
-    '/js/itinerary.js',
-    '/data/miyakojima_pois.json',
+    'index.html',
+    'css/main.css',
+    'css/mobile.css',
+    'js/app.js',
+    'js/config.js',
+    'js/utils.js',
+    'js/api.js',
+    'js/budget.js',
+    'js/location.js',
+    'js/poi.js',
+    'js/itinerary.js',
+    'data/miyakojima_pois.json',
     'https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap',
     'https://cdnjs.cloudflare.com/ajax/libs/tesseract.js/2.1.5/tesseract.min.js'
 ];


### PR DESCRIPTION
The miyakojima-web application was failing to load when deployed to a subdirectory on GitHub Pages. This was caused by the use of absolute paths for assets, which resulted in 404 errors.

This commit addresses the issue by:
- Updating the `STATIC_FILES` array in `sw.js` to use relative paths for all local assets.
- Changing the service worker registration in `js/app.js` to use a relative path.

Additionally, a minor code quality issue was fixed by removing a duplicate `DEBUG` key in `js/config.js`.