### PR TITLE
fix(sw): Use explicit relative paths for cache assets

### DIFF
--- a/miyakojima/miyakojima-web/sw.js
+++ b/miyakojima/miyakojima-web/sw.js
@@ -5,18 +5,18 @@ const DATA_CACHE = 'data-v1';
 
 // Files to cache immediately
 const STATIC_FILES = [
-    'index.html',
-    'css/main.css',
-    'css/mobile.css',
-    'js/app.js',
-    'js/config.js',
-    'js/utils.js',
-    'js/api.js',
-    'js/budget.js',
-    'js/location.js',
-    'js/poi.js',
-    'js/itinerary.js',
-    'data/miyakojima_pois.json',
+    './index.html',
+    './css/main.css',
+    './css/mobile.css',
+    './js/app.js',
+    './js/config.js',
+    './js/utils.js',
+    './js/api.js',
+    './js/budget.js',
+    './js/location.js',
+    './js/poi.js',
+    './js/itinerary.js',
+    './data/miyakojima_pois.json',
     'https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap',
     'https://cdnjs.cloudflare.com/ajax/libs/tesseract.js/2.1.5/tesseract.min.js'
 ];


### PR DESCRIPTION
This change corrects the service worker installation failure by making all cached file paths explicitly relative (e.g., './index.html').

The previous fix, which used simple relative paths (e.g., 'index.html'), was not sufficient due to either browser-specific behavior or a persistent caching issue. Using an explicit './' prefix ensures the paths are correctly resolved relative to the service worker's location, which is critical for deployments in a subdirectory on GitHub Pages.