### PR TITLE
fix: Hide dynamic loader to resolve final loading issue

### DIFF
--- a/miyakojima/miyakojima-web/js/app.js
+++ b/miyakojima/miyakojima-web/js/app.js
@@ -421,10 +421,14 @@ class ModuleInitializer {
     }
     
     hideLoadingState() {
-        // 로딩 화면 숨기기
-        const loader = document.getElementById('loading-screen');
-        if (loader) {
-            loader.style.display = 'none';
+        // 로딩 화면 숨기기 (정적/동적 로더 모두 처리)
+        const staticLoader = document.getElementById('loading-screen');
+        if (staticLoader) {
+            staticLoader.style.display = 'none';
+        }
+        const dynamicLoader = document.getElementById('app-loader');
+        if (dynamicLoader) {
+            dynamicLoader.style.display = 'none';
         }
         
         // 메인 콘텐츠 표시


### PR DESCRIPTION
This commit resolves the final issue where the application content would load but a loading screen would remain on top.

The root cause was a dynamically created loader (`#app-loader`) in `js/app.js` that was not being hidden by the `hideLoadingState` function. The function has been updated to hide both the static `#loading-screen` and the dynamic `#app-loader`, ensuring the UI is correctly revealed after initialization.

This change, combined with the previous pathing fixes, should completely resolve the application loading failures.